### PR TITLE
don't initialise 'foreach' variable in rewriter

### DIFF
--- a/src/SharpSyntaxRewriter/Rewriters/InitializeOutArgument.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/InitializeOutArgument.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using SharpSyntaxRewriter.Extensions;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -97,6 +98,15 @@ namespace SharpSyntaxRewriter.Rewriters
                 return node;
 
             return base.VisitParenthesizedLambdaExpression(node);
+        }
+
+        public override SyntaxNode VisitForEachVariableStatement(ForEachVariableStatementSyntax node)
+        {
+            var expr_P = (ExpressionSyntax)node.Expression.Accept(this);
+            var stmt_P = (StatementSyntax)node.Statement.Accept(this);
+
+            return node.WithExpression(expr_P)
+                       .WithStatement(stmt_P);
         }
 
         public override SyntaxNode VisitQueryExpression(QueryExpressionSyntax node)

--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>SharpSyntaxRewriter</PackageId>
-    <PackageVersion>1.0.31</PackageVersion>
+    <PackageVersion>1.0.32</PackageVersion>
     <Authors>Leandro T. C. Melo</Authors>
     <Copyright>ShiftLeft Inc.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/tests/TestDecomposeNullConditional.cs
+++ b/tests/TestDecomposeNullConditional.cs
@@ -830,43 +830,5 @@ class Test
 
             TestRewrite_LinePreserve(original, expected);
         }
-
-        [TestMethod]
-        public void TestDecomposeNullConditionalWithOutVarInCallPrefix()
-        {
-            var original = @"
-public class Ccc
-{
-    public Ccc ggg(out int ppp) { ppp = 111; return null; }
-
-    public Ccc kkk() { return null; }
-
-    public void fff()
-    {
-        Ccc ooo = null;
-
-        ooo.ggg(out int qqq)?.kkk();
-    }
-}
-";
-
-            var expected = @"
-public class Ccc
-{
-    public Ccc ggg(out int ppp) { ppp = 111; return null; }
-
-    public Ccc kkk() { return null; }
-
-    public void fff()
-    {
-        Ccc ooo = null;
-
-        if ((object)ooo.ggg(out int qqq)!=null) ooo.ggg(out int qqq).kkk();
-    }
-}
-";
-
-            TestRewrite_LinePreserve(original, expected);
-        }
     }
 }

--- a/tests/TestDecomposeNullConditional.cs
+++ b/tests/TestDecomposeNullConditional.cs
@@ -830,5 +830,43 @@ class Test
 
             TestRewrite_LinePreserve(original, expected);
         }
+
+        [TestMethod]
+        public void TestDecomposeNullConditionalWithOutVarInCallPrefix()
+        {
+            var original = @"
+public class Ccc
+{
+    public Ccc ggg(out int ppp) { ppp = 111; return null; }
+
+    public Ccc kkk() { return null; }
+
+    public void fff()
+    {
+        Ccc ooo = null;
+
+        ooo.ggg(out int qqq)?.kkk();
+    }
+}
+";
+
+            var expected = @"
+public class Ccc
+{
+    public Ccc ggg(out int ppp) { ppp = 111; return null; }
+
+    public Ccc kkk() { return null; }
+
+    public void fff()
+    {
+        Ccc ooo = null;
+
+        if ((object)ooo.ggg(out int qqq)!=null) ooo.ggg(out int qqq).kkk();
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
     }
 }

--- a/tests/TestInitializeOutArgument.cs
+++ b/tests/TestInitializeOutArgument.cs
@@ -632,5 +632,69 @@ public class Abc
 
             TestRewrite_LinePreserve(original, expected);
         }
+
+        [TestMethod]
+        public void TestInitializeOutArgumentDontAffectForeachVariable()
+        {
+            var original = @"
+using System.Collections.Generic;
+
+public class Ccc
+{
+    public void fff()
+    {
+        List<int> l = null;
+        foreach (var i in l) {}
+    }
+}
+";
+
+            var expected = @"
+using System.Collections.Generic;
+
+public class Ccc
+{
+    public void fff()
+    {
+        List<int> l = null;
+        foreach (var i in l) {}
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestInitializeOutArgumentDontAffectForeachAggregateVariable()
+        {
+            var original = @"
+using System.Collections.Generic;
+
+public class Ccc
+{
+    public void fff()
+    {
+        List<(int, double)> l = null;
+        foreach ((var i, var d) in l) {}
+    }
+}
+";
+
+            var expected = @"
+using System.Collections.Generic;
+
+public class Ccc
+{
+    public void fff()
+    {
+        List<(int, double)> l = null;
+        foreach ((var i, var d) in l) {}
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
     }
 }


### PR DESCRIPTION
`foreach` has an specific rule