### PR TITLE
fix error of type display in decompose `null` conditional

### DIFF
--- a/src/SharpSyntaxRewriter/Rewriters/DecomposeNullConditional.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/DecomposeNullConditional.cs
@@ -217,7 +217,8 @@ namespace SharpSyntaxRewriter.Rewriters
                 falseExpr =
                     SyntaxFactory.CastExpression(
                         SyntaxFactory.NullableType(
-                            SyntaxFactory.ParseTypeName(exprTySym.ToString())),
+                            SyntaxFactory.ParseTypeName(
+                                exprTySym.ToMinimalDisplayString(_semaModel, node.SpanStart))),
                         falseExpr);
             }
 

--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>SharpSyntaxRewriter</PackageId>
-    <PackageVersion>1.0.32</PackageVersion>
+    <PackageVersion>1.0.33</PackageVersion>
     <Authors>Leandro T. C. Melo</Authors>
     <Copyright>ShiftLeft Inc.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
   </ItemGroup>
 
   <ProjectExtensions>

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.9.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
and bump versions (also of Roslyn)