### PR TITLE
use operation's type as the result type of an expr (if the expr's type info is null)

### DIFF
--- a/src/SharpSyntaxRewriter/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/SharpSyntaxRewriter/Extensions/ExpressionSyntaxExtensions.cs
@@ -11,7 +11,7 @@ namespace SharpSyntaxRewriter.Extensions
     public enum ResolutionAccuracy
     {
         Exact,
-        Transitive
+        Approximate
     }
 
     public static class ExpressionSyntaxExtensions
@@ -29,8 +29,8 @@ namespace SharpSyntaxRewriter.Extensions
             };
         }
 
-        public static ITypeSymbol ResolveType(this ExpressionSyntax exprNode,
-                                              SemanticModel semaModel)
+        public static ITypeSymbol ResultType(this ExpressionSyntax exprNode,
+                                             SemanticModel semaModel)
         {
             Debug.Assert(semaModel != null);
 

--- a/src/SharpSyntaxRewriter/Extensions/ExpressionSyntaxExtensions.cs
+++ b/src/SharpSyntaxRewriter/Extensions/ExpressionSyntaxExtensions.cs
@@ -36,17 +36,27 @@ namespace SharpSyntaxRewriter.Extensions
 
             var tySym = semaModel.GetTypeInfo(exprNode).ConvertedType;
 
-            if (tySym is ITypeParameterSymbol tyParmSym
-                    && exprNode is SimpleNameSyntax nameNode)
+            switch (tySym)
             {
-                return tyParmSym.SpecializedFor(nameNode);
+                case null:
+                    var op = semaModel.GetOperation(exprNode);
+                    if (op != null && op.Kind != OperationKind.None)
+                        return op.Type;
+                    break;
+
+                case ITypeParameterSymbol tyParmSym:
+                    // REVIEW: This "specialization" should be based on type constraints.
+                    if (exprNode is SimpleNameSyntax nameNode)
+                        return tyParmSym.SpecializedFor(nameNode);
+                    break;
             }
+
             return tySym;
         }
 
-        public static ISymbol ResolveSymbol(this ExpressionSyntax exprNode,
-                                            SemanticModel semaModel,
-                                            ResolutionAccuracy accuracy)
+        public static ISymbol ResolvedSymbol(this ExpressionSyntax exprNode,
+                                             SemanticModel semaModel,
+                                             ResolutionAccuracy accuracy)
         {
             Debug.Assert(semaModel != null);
 

--- a/src/SharpSyntaxRewriter/Rewriters/DecomposeNullConditional.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/DecomposeNullConditional.cs
@@ -292,7 +292,7 @@ namespace SharpSyntaxRewriter.Rewriters
             if (decomp)
             {
                 var sym = node.ResolveSymbol(_semaModel,
-                                             ResolutionAccuracy.Transitive);
+                                               ResolutionAccuracy.Approximate);
                 if (sym is IMethodSymbol methSym
                         && ReturnTypeInfo.ImpliesVoid(methSym.ReturnType, methSym.IsAsync))
                 {

--- a/src/SharpSyntaxRewriter/Rewriters/DecomposeNullConditional.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/DecomposeNullConditional.cs
@@ -291,8 +291,8 @@ namespace SharpSyntaxRewriter.Rewriters
 
             if (decomp)
             {
-                var sym = node.ResolveSymbol(_semaModel,
-                                               ResolutionAccuracy.Approximate);
+                var sym = node.ResolvedSymbol(_semaModel,
+                                              ResolutionAccuracy.Approximate);
                 if (sym is IMethodSymbol methSym
                         && ReturnTypeInfo.ImpliesVoid(methSym.ReturnType, methSym.IsAsync))
                 {

--- a/src/SharpSyntaxRewriter/Rewriters/ReplicateLocalInitialization.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/ReplicateLocalInitialization.cs
@@ -336,7 +336,7 @@ namespace SharpSyntaxRewriter.Rewriters
                 return node;
 
             var storeTySym = storeObj is ExpressionSyntax
-                    ? (storeObj as ExpressionSyntax).ResolveType(_semaModel)
+                    ? (storeObj as ExpressionSyntax).ResultType(_semaModel)
                     : _semaModel.GetDeclaredSymbol(storeObj).ValueType();
 
             // If the assigned type is different (e.g., a base type) than the type of the object

--- a/src/SharpSyntaxRewriter/Rewriters/StoreObjectCreation.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/StoreObjectCreation.cs
@@ -43,8 +43,8 @@ namespace SharpSyntaxRewriter.Rewriters
             if (node.Parent is AssignmentExpressionSyntax assgExpr
                     && !(node.Parent.Parent is InitializerExpressionSyntax))
             {
-                var sym = assgExpr.Left.ResolveSymbol(_semaModel,
-                                                        ResolutionAccuracy.Exact);
+                var sym = assgExpr.Left.ResolvedSymbol(_semaModel,
+                                                       ResolutionAccuracy.Exact);
                 if (sym is ILocalSymbol || sym is IParameterSymbol)
                     return node_P;
             }

--- a/src/SharpSyntaxRewriter/Rewriters/StoreObjectCreation.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/StoreObjectCreation.cs
@@ -44,7 +44,7 @@ namespace SharpSyntaxRewriter.Rewriters
                     && !(node.Parent.Parent is InitializerExpressionSyntax))
             {
                 var sym = assgExpr.Left.ResolveSymbol(_semaModel,
-                                                      ResolutionAccuracy.Exact);
+                                                        ResolutionAccuracy.Exact);
                 if (sym is ILocalSymbol || sym is IParameterSymbol)
                     return node_P;
             }
@@ -79,7 +79,7 @@ namespace SharpSyntaxRewriter.Rewriters
 
         public override SyntaxNode VisitSwitchExpression(SwitchExpressionSyntax node)
         {
-            var tySym = node.ResolveType(_semaModel);
+            var tySym = node.ResultType(_semaModel);
 
             return VisitCreationExpression(
                         node,

--- a/src/SharpSyntaxRewriter/Rewriters/Types/SymbolicRewriter.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/Types/SymbolicRewriter.cs
@@ -28,7 +28,7 @@ namespace SharpSyntaxRewriter.Rewriters.Types
 
         public bool IsExpressionTreeVisit(AnonymousFunctionExpressionSyntax node)
         {
-            return node.ResolveType(_semaModel).IsExpressionTree();
+            return node.ResultType(_semaModel).IsExpressionTree();
         }
     }
 }

--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>SharpSyntaxRewriter</PackageId>
-    <PackageVersion>1.0.37</PackageVersion>
+    <PackageVersion>1.0.38</PackageVersion>
     <Authors>Leandro T. C. Melo</Authors>
     <Copyright>ShiftLeft Inc.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>


### PR DESCRIPTION
also rename related api