### PR TITLE
fix implementation of (readonly) auto property that is accessed through `++` (and similar)

### DIFF
--- a/src/SharpSyntaxRewriter/Rewriters/ImplementAutoProperty.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/ImplementAutoProperty.cs
@@ -281,9 +281,20 @@ namespace SharpSyntaxRewriter.Rewriters
         /*
          * See https://github.com/dotnet/csharplang/issues/2468 for the reason of this visit.
          */
+        private bool __withinCtor;
+
+        public override SyntaxNode VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
+        {
+            __withinCtor = true;
+            var node_P = base.VisitConstructorDeclaration(node);
+            __withinCtor = false;
+
+            return node_P;
+        }
+
         public override SyntaxNode VisitAssignmentExpression(AssignmentExpressionSyntax node)
         {
-            if (!node.Ancestors().OfType<ConstructorDeclarationSyntax>().Any())
+            if (!__withinCtor)
                 return node;
 
             var node_P = node.WithRight((ExpressionSyntax)node.Right.Accept(this));

--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>SharpSyntaxRewriter</PackageId>
-    <PackageVersion>1.0.44</PackageVersion>
+    <PackageVersion>1.0.45</PackageVersion>
     <Authors>Leandro T. C. Melo</Authors>
     <Copyright>ShiftLeft Inc.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/tests/TestImplementAutoProperty.cs
+++ b/tests/TestImplementAutoProperty.cs
@@ -873,5 +873,35 @@ public class A
 
             TestRewrite_LinePreserve(original, expected);
         }
+
+        [TestMethod]
+        public void Test_TEMP()
+        {
+            var original = @"
+public class PagedList
+{
+    public int TotalPages { get; }
+
+    public PagedList()
+    {
+        TotalPages++;
+    }
+}
+";
+
+            var expected = @"
+public class PagedList
+{
+    public int TotalPages { get { return ____LT____TotalPages____GT____k_BackingField; } } public int ____LT____TotalPages____GT____k_BackingField;
+
+    public PagedList()
+    {
+        ____LT____TotalPages____GT____k_BackingField++;
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
     }
 }

--- a/tests/TestImplementAutoProperty.cs
+++ b/tests/TestImplementAutoProperty.cs
@@ -875,7 +875,7 @@ public class A
         }
 
         [TestMethod]
-        public void Test_TEMP()
+        public void TestImplementAutoPropertyWithOnlyGetAccessorButWriteAccessInPostIncrement()
         {
             var original = @"
 public class PagedList
@@ -897,6 +897,36 @@ public class PagedList
     public PagedList()
     {
         ____LT____TotalPages____GT____k_BackingField++;
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestImplementAutoPropertyWithOnlyGetAccessorButWriteAccessInPreIncrement()
+        {
+            var original = @"
+public class PagedList
+{
+    public int TotalPages { get; }
+
+    public PagedList()
+    {
+        ++TotalPages;
+    }
+}
+";
+
+            var expected = @"
+public class PagedList
+{
+    public int TotalPages { get { return ____LT____TotalPages____GT____k_BackingField; } } public int ____LT____TotalPages____GT____k_BackingField;
+
+    public PagedList()
+    {
+        ++____LT____TotalPages____GT____k_BackingField;
     }
 }
 ";


### PR DESCRIPTION
A C# auto property can bet *set* within a constructor even if the property is declared with a `get` accessor only (these properties are "readonly"). So when we (manually) implement an auto property, we currently account for such *set* accesses when the access is within an assignment expression; but we must also account for them within pre/post increment/decrement expressions.

This PR extends, for pre/post increment/decrement expressions, the rewriting behaviour that already exists for assignment expressions. See the 2 new test cases.

Note: the code could have been more reusable if `PrefixUnaryExpressionSyntax` and `PostfixUnaryExpressionSyntax` had a common base class… or if we create an "adaptor" for these classes as we do for certain other syntaxes (but creating the adaptor is only worth it if we see this "pattern" occurring more often).