### PR TITLE
don't replace `readonly` auto property access (in ctor) from another class

### DIFF
--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>SharpSyntaxRewriter</PackageId>
-    <PackageVersion>1.0.45</PackageVersion>
+    <PackageVersion>1.0.46</PackageVersion>
     <Authors>Leandro T. C. Melo</Authors>
     <Copyright>ShiftLeft Inc.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/tests/TestImplementAutoProperty.cs
+++ b/tests/TestImplementAutoProperty.cs
@@ -933,5 +933,53 @@ public class PagedList
 
             TestRewrite_LinePreserve(original, expected);
         }
+
+        [TestMethod]
+        public void TestImplementAutoPropertyPropertyWithOnlyGetAccessorFromOtherClass()
+        {
+            var original = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Name
+{
+    public bool IsEmpty => false;
+}
+
+public class PagedList
+{
+    public PagedList()
+    {
+        Name nnn = null;
+        var eee = nnn.IsEmpty;
+        IEnumerable<Name> ParseQuery(string qqq) => qqq.Split('-').Select(aaa => new Name()).Where(aaa => !aaa.IsEmpty);
+    }
+}
+";
+
+            var expected = @"
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+public class Name
+{
+    public bool IsEmpty => false;
+}
+
+public class PagedList
+{
+    public PagedList()
+    {
+        Name nnn = null;
+        var eee = nnn.IsEmpty;
+        IEnumerable<Name> ParseQuery(string qqq) => qqq.Split('-').Select(aaa => new Name()).Where(aaa => !aaa.IsEmpty);
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
     }
 }


### PR DESCRIPTION
pr #28 introduced a regression: it was replacing an access to a readonly property but without checking whether the property in question was contained in the class undergoing an auto property implementation;
this pr fixes that regression