### PR TITLE
account for .NET 6's custom string interpolation handlers

### DIFF
--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>SharpSyntaxRewriter</PackageId>
-    <PackageVersion>1.0.46</PackageVersion>
+    <PackageVersion>1.0.47</PackageVersion>
     <Authors>Leandro T. C. Melo</Authors>
     <Copyright>ShiftLeft Inc.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/tests/TestUninterpolateString.cs
+++ b/tests/TestUninterpolateString.cs
@@ -349,5 +349,41 @@ public class CCC
 
             TestRewrite_LinePreserve(original, expected);
         }
+
+        [TestMethod]
+        public void TestUninterpolateStringChangedBehaviorFromNET5ToNET6()
+        {
+            var original = @"
+using System;
+using System.Text;
+
+public class AAA
+{
+    private readonly int sss;
+    public void fff()
+    {
+        StringBuilder sb = null;
+        sb.AppendLine($""{sss}"");
+    }
+}
+";
+
+            var expected = @"
+using System;
+using System.Text;
+
+public class AAA
+{
+    private readonly int sss;
+    public void fff()
+    {
+        StringBuilder sb = null;
+        sb.AppendLine(string.Format(""{0}"",sss));
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
     }
 }


### PR DESCRIPTION
on .NET 5, the new test case will pass regardless of the change made in the rewrite, (possibly) giving the impression that the change in the rewrite is unnecessary; however, on .NET 6 the test case will fail without the change in the rewrite.

NOTE: currently we run our tests on a .NET 5 built, but the rewrites themselves can be applied on projects whose symbols were computed on .NET 6.