### PR TITLE
fix rewrite to emplace global statements and test tests for it

### DIFF
--- a/src/SharpSyntaxRewriter/Rewriters/EmplaceGlobalStatement.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/EmplaceGlobalStatement.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Collections.Generic;
+using System;
 using System.Linq;
 
 using SharpSyntaxRewriter.Rewriters.Types;
@@ -22,6 +23,8 @@ namespace SharpSyntaxRewriter.Rewriters
 
         private readonly List<StatementSyntax> __stmtsNodes = new();
 
+        private SyntaxTriviaList __tyDeclLeadTrivia;
+
         public override SyntaxNode VisitCompilationUnit(CompilationUnitSyntax node)
         {
             var node_P = (CompilationUnitSyntax)base.VisitCompilationUnit(node);
@@ -29,28 +32,56 @@ namespace SharpSyntaxRewriter.Rewriters
             if (!__stmtsNodes.Any())
                 return node_P;
 
-            var tyDecl =
-                SyntaxFactory.ClassDeclaration("<Program>$")
-                    .WithMembers(
-                        SyntaxFactory.List<MemberDeclarationSyntax>().Add(
-                            SyntaxFactory.MethodDeclaration(
-                                    SyntaxFactory.ParseTypeName("void"),
-                                    "<Main>$")
-                                .WithModifiers(
-                                    SyntaxFactory.TokenList(
-                                        SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
-                                        SyntaxFactory.Token(SyntaxKind.StaticKeyword)))
-                                .WithBody(SyntaxFactory.Block(__stmtsNodes))));
+            var lastStmt = __stmtsNodes.Last();
+            __stmtsNodes.Remove(lastStmt);
+            __stmtsNodes.Add(lastStmt.WithoutTrailingTrivia());
 
-            node_P = node_P.AddMembers(tyDecl);
+            var methDecl =
+                SyntaxFactory.MethodDeclaration(
+                        SyntaxFactory.ParseTypeName("void"),
+                        "Main")
+                    .WithModifiers(
+                        SyntaxFactory.TokenList(
+                            SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
+                            SyntaxFactory.Token(SyntaxKind.StaticKeyword)))
+                    .WithBody(
+                        SyntaxFactory.Block(__stmtsNodes));
+
+            var tyDecl =
+                SyntaxFactory.ClassDeclaration("__Program__")
+                    .WithModifiers(
+                        SyntaxFactory.TokenList(
+                            SyntaxFactory.Token(SyntaxKind.InternalKeyword),
+                            SyntaxFactory.Token(SyntaxKind.StaticKeyword)))
+                    .WithMembers(
+                        SyntaxFactory.List<MemberDeclarationSyntax>().Add(methDecl))
+                    .WithLeadingTrivia(__tyDeclLeadTrivia);
+
+            node_P = node_P.AddMembers(tyDecl).WithTrailingTrivia(lastStmt.GetTrailingTrivia());
 
             return node_P;
         }
 
         public override SyntaxNode VisitGlobalStatement(GlobalStatementSyntax node)
         {
+            if (!__stmtsNodes.Any())
+            {
+                __tyDeclLeadTrivia = __tyDeclLeadTrivia.AddRange(node.GetLeadingTrivia());
+                node = node.WithoutLeadingTrivia();
+            }
+
             __stmtsNodes.Add(node.Statement);
+
             return null;
+        }
+
+        public override SyntaxNode VisitUsingDirective(UsingDirectiveSyntax node)
+        {
+            node = node.WithLeadingTrivia(node.GetLeadingTrivia().AddRange(__tyDeclLeadTrivia));
+            __tyDeclLeadTrivia = node.GetTrailingTrivia();
+            node = node.WithoutTrailingTrivia();
+
+            return node;
         }
     }
 }

--- a/src/SharpSyntaxRewriter/Rewriters/EmplaceGlobalStatement.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/EmplaceGlobalStatement.cs
@@ -38,7 +38,8 @@ namespace SharpSyntaxRewriter.Rewriters
 
             var methDecl =
                 SyntaxFactory.MethodDeclaration(
-                        SyntaxFactory.ParseTypeName("void"),
+                        SyntaxFactory.PredefinedType(
+                            SyntaxFactory.Token(SyntaxKind.VoidKeyword)),
                         "Main")
                     .WithModifiers(
                         SyntaxFactory.TokenList(

--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>SharpSyntaxRewriter</PackageId>
-    <PackageVersion>1.0.47</PackageVersion>
+    <PackageVersion>1.0.48</PackageVersion>
     <Authors>Leandro T. C. Melo</Authors>
     <Copyright>ShiftLeft Inc.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/tests/BaseTester.cs
+++ b/tests/BaseTester.cs
@@ -43,8 +43,7 @@ namespace Tests
         protected static void CheckCompilation(Compilation compilation)
         {
             var errorCnt = compilation.GetDiagnostics()
-                    .Where(d => d.Severity == DiagnosticSeverity.Error
-                                && d.Descriptor.Id != "CS1547")
+                    .Where(d => d.Severity == DiagnosticSeverity.Error)
                     .Count();
 
 #if DEBUG_SYNTAX

--- a/tests/BaseTester.cs
+++ b/tests/BaseTester.cs
@@ -43,7 +43,8 @@ namespace Tests
         protected static void CheckCompilation(Compilation compilation)
         {
             var errorCnt = compilation.GetDiagnostics()
-                    .Where(d => d.Severity == DiagnosticSeverity.Error)
+                    .Where(d => d.Severity == DiagnosticSeverity.Error
+                                && d.Descriptor.Id != "CS1547")
                     .Count();
 
 #if DEBUG_SYNTAX
@@ -56,7 +57,12 @@ namespace Tests
             }
 #endif
 
-            Assert.AreEqual(0, errorCnt);
+            Assert.AreEqual(0, errorCnt, "rewritten syntax tree has errors");
+        }
+
+        protected void CompileAsExecutable()
+        {
+            __compiler.OutputKindCompilationOpt = OutputKind.ConsoleApplication;
         }
     }
 }

--- a/tests/Compiler.cs
+++ b/tests/Compiler.cs
@@ -16,8 +16,8 @@ namespace Tests
         {
             return CSharpCompilation.Create("<default-compilation>",
                                             trees.ToList(),
-                                            metadataRefs__,
-                                            compilationOpts__);
+                                            __metadataRefs,
+                                            __compilationOpts);
         }
 
         public (Compilation, List<SyntaxTree>) CompileSourceTexts(
@@ -28,7 +28,7 @@ namespace Tests
             return (CompileSyntaxTrees(trees.ToArray()), trees);
         }
 
-        private CSharpParseOptions parseOpts__
+        private CSharpParseOptions __parseOpts
         {
             get
             {
@@ -38,13 +38,15 @@ namespace Tests
             }
         }
 
-        private CSharpCompilationOptions compilationOpts__
+        public OutputKind OutputKindCompilationOpt { get; set; } = OutputKind.DynamicallyLinkedLibrary;
+
+        private CSharpCompilationOptions __compilationOpts
         {
             get
             {
                 return
                     new CSharpCompilationOptions(
-                        OutputKind.DynamicallyLinkedLibrary,
+                        OutputKindCompilationOpt,
                         allowUnsafe: true,
                         optimizationLevel: OptimizationLevel.Debug,
                         platform: Platform.AnyCpu,
@@ -52,7 +54,7 @@ namespace Tests
             }
         }
 
-        private IEnumerable<MetadataReference> metadataRefs__
+        private IEnumerable<MetadataReference> __metadataRefs
         {
             get
             {

--- a/tests/TestEmplaceGlobalStatement.cs
+++ b/tests/TestEmplaceGlobalStatement.cs
@@ -1,0 +1,75 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+using SharpSyntaxRewriter.Rewriters;
+
+namespace Tests
+{
+    [TestClass]
+    public class TestEmplaceGlobalStatement : RewriterTester
+    {
+        protected override SyntaxTree ApplyRewrite(SyntaxTree tree, Compilation compilation)
+        {
+            return new EmplaceGlobalStatement().Apply(tree);
+        }
+
+        [TestMethod]
+        public void TestEmplaceGlobalStatement1()
+        {
+            var original = @"
+using System;
+Console.Write(1);
+";
+
+            var expected = @"
+using System;
+internal static class __Program__ { private static void Main() { Console.Write(1); } }
+";
+
+            CompileAsExecutable();
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestEmplaceGlobalStatement2()
+        {
+            var original = @"
+using System;
+
+Console.Write(1);
+";
+
+            var expected = @"
+using System;
+
+internal static class __Program__ { private static void Main() { Console.Write(1); } }
+";
+
+            CompileAsExecutable();
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestEmplaceGlobalStatement3()
+        {
+            var original = @"
+using System;
+
+Console.Write(1);
+
+Console.Write(2);
+";
+
+            var expected = @"
+using System;
+
+internal static class __Program__ { private static void Main() { Console.Write(1);
+
+Console.Write(2); } }
+";
+
+            CompileAsExecutable();
+            TestRewrite_LinePreserve(original, expected);
+        }
+    }
+}


### PR DESCRIPTION
Use `SyntaxFactory.Token(SyntaxKind.VoidKeyword))` instead of `SyntaxFactory.ParseTypeName("void")` and make names rewritable to C# source (valid identifiers, without `<>$`).
Also adjust trivia.
