### PR TITLE
preserver original `CompilationUnitSyntax` node if no global statements are rewritten

### DIFF
--- a/src/SharpSyntaxRewriter/Rewriters/EmplaceGlobalStatement.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/EmplaceGlobalStatement.cs
@@ -30,7 +30,7 @@ namespace SharpSyntaxRewriter.Rewriters
             var node_P = (CompilationUnitSyntax)base.VisitCompilationUnit(node);
 
             if (!__stmtsNodes.Any())
-                return node_P;
+                return node;
 
             var lastStmt = __stmtsNodes.Last();
             __stmtsNodes.Remove(lastStmt);

--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>SharpSyntaxRewriter</PackageId>
-    <PackageVersion>1.0.48</PackageVersion>
+    <PackageVersion>1.0.49</PackageVersion>
     <Authors>Leandro T. C. Melo</Authors>
     <Copyright>ShiftLeft Inc.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>


### PR DESCRIPTION
this is particularly useful for logic that relies on comparison between an "old" and a rewritten AST