### PR TITLE
add the `string[] args` parameter of `Main` when emplacing global statements

### DIFF
--- a/src/SharpSyntaxRewriter/Rewriters/EmplaceGlobalStatement.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/EmplaceGlobalStatement.cs
@@ -45,6 +45,18 @@ namespace SharpSyntaxRewriter.Rewriters
                         SyntaxFactory.TokenList(
                             SyntaxFactory.Token(SyntaxKind.PrivateKeyword),
                             SyntaxFactory.Token(SyntaxKind.StaticKeyword)))
+                    .WithParameterList(
+                        SyntaxFactory.ParameterList(
+                                SyntaxFactory.SeparatedList(
+                                    new List<ParameterSyntax>()
+                                    {
+                                        SyntaxFactory.Parameter(
+                                            SyntaxFactory.List<AttributeListSyntax>(),
+                                            SyntaxFactory.TokenList(),
+                                            SyntaxFactory.ParseTypeName("string[]"),
+                                            SyntaxFactory.Identifier("args"),
+                                            null)
+                                    })))
                     .WithBody(
                         SyntaxFactory.Block(__stmtsNodes));
 

--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>SharpSyntaxRewriter</PackageId>
-    <PackageVersion>1.0.49</PackageVersion>
+    <PackageVersion>1.0.50</PackageVersion>
     <Authors>Leandro T. C. Melo</Authors>
     <Copyright>ShiftLeft Inc.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/tests/TestEmplaceGlobalStatement.cs
+++ b/tests/TestEmplaceGlobalStatement.cs
@@ -23,7 +23,7 @@ Console.Write(1);
 
             var expected = @"
 using System;
-internal static class __Program__ { private static void Main() { Console.Write(1); } }
+internal static class __Program__ { private static void Main(string[] args) { Console.Write(1); } }
 ";
 
             CompileAsExecutable();
@@ -42,7 +42,7 @@ Console.Write(1);
             var expected = @"
 using System;
 
-internal static class __Program__ { private static void Main() { Console.Write(1); } }
+internal static class __Program__ { private static void Main(string[] args) { Console.Write(1); } }
 ";
 
             CompileAsExecutable();
@@ -63,9 +63,28 @@ Console.Write(2);
             var expected = @"
 using System;
 
-internal static class __Program__ { private static void Main() { Console.Write(1);
+internal static class __Program__ { private static void Main(string[] args) { Console.Write(1);
 
 Console.Write(2); } }
+";
+
+            CompileAsExecutable();
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestEmplaceGlobalStatement4()
+        {
+            var original = @"
+using System;
+
+Console.Write(args);
+";
+
+            var expected = @"
+using System;
+
+internal static class __Program__ { private static void Main(string[] args) { Console.Write(args);  } }
 ";
 
             CompileAsExecutable();


### PR DESCRIPTION
as it's actually passed implicitly and can be be used by global statements