### PR TITLE
rewriter to extract declarations out of a `DeclarationPattern`

### DIFF
--- a/src/SharpSyntaxRewriter/Rewriters/ExtractDeclarationFromPattern.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/ExtractDeclarationFromPattern.cs
@@ -88,7 +88,7 @@ namespace SharpSyntaxRewriter.Rewriters
         {
             /*
              * A `switch' expression may contain `switch' "arms" with declaration patterns
-             * whose declared name are the same; but we don't want to replicate these declarations.
+             * whose name are the same; but we don't want to replicate these declarations.
              */
             __declaredNames.Push(new HashSet<string>());
 

--- a/src/SharpSyntaxRewriter/Rewriters/ExtractDeclarationFromPattern.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/ExtractDeclarationFromPattern.cs
@@ -81,6 +81,28 @@ namespace SharpSyntaxRewriter.Rewriters
                         node.Expression,
                         declPatt.Type);
         }
+
+        public override SyntaxNode VisitSwitchExpression(SwitchExpressionSyntax node)
+        {
+            __exprs.Push(node.GoverningExpression);
+            var node_P = (SwitchExpressionSyntax)base.VisitSwitchExpression(node);
+            __exprs.Pop();
+
+            return node_P;
+        }
+
+        public override SyntaxNode VisitSwitchExpressionArm(SwitchExpressionArmSyntax node)
+        {
+            if (node.Pattern is not DeclarationPatternSyntax declPatt
+                    || declPatt.Designation is not SingleVariableDesignationSyntax)
+            {
+                return node;
+            }
+
+            var node_P = (SwitchExpressionArmSyntax)base.VisitSwitchExpressionArm(node);
+
+            return node_P.WithPattern(SyntaxFactory.ConstantPattern(declPatt.Type));
+        }
     }
 }
 

--- a/src/SharpSyntaxRewriter/Rewriters/ExtractDeclarationFromPattern.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/ExtractDeclarationFromPattern.cs
@@ -1,0 +1,86 @@
+﻿// Copyright 2021 ShiftLeft, Inc.
+// Author: Leandro T. C. Melo
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using SharpSyntaxRewriter.Extensions;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+using SharpSyntaxRewriter.Rewriters.Types;
+using System.Diagnostics;
+
+namespace SharpSyntaxRewriter.Rewriters
+{
+    public class ExtractDeclarationFromPattern : StatementSynthesizerRewriter
+    {
+        public const string ID = "<extract declaration from pattern>";
+
+        public override string Name()
+        {
+            return ID;
+        }
+
+        public override SyntaxNode VisitDeclarationPattern(DeclarationPatternSyntax node)
+        {
+            Debug.Assert(node.Designation is SingleVariableDesignationSyntax);
+            var varDesig = (SingleVariableDesignationSyntax)node.Designation;
+
+            var declStmt =
+                SyntaxFactory.LocalDeclarationStatement(
+                    SyntaxFactory.VariableDeclaration(
+                        node.Type,
+                        SyntaxFactory.SingletonSeparatedList(
+                            SyntaxFactory.VariableDeclarator(
+                                varDesig.Identifier.WithoutTrivia(),
+                                null,
+                                SyntaxFactory.EqualsValueClause(
+                                    SyntaxFactory.DefaultExpression(node.Type))))));
+
+            Debug.Assert(__exprs.Any());
+            var expr = __exprs.Peek();
+
+            var ifStmt =
+                SyntaxFactory.IfStatement(
+                    SyntaxFactory.BinaryExpression(
+                        SyntaxKind.IsExpression,
+                        expr,
+                        node.Type),
+                    SyntaxFactory.ExpressionStatement(
+                        SyntaxFactory.AssignmentExpression(
+                            SyntaxKind.SimpleAssignmentExpression,
+                            SyntaxFactory.IdentifierName(varDesig.Identifier),
+                            SyntaxFactory.CastExpression(
+                                node.Type,
+                                expr))));
+
+            _ctx.Peek().Add(declStmt);
+            _ctx.Peek().Add(ifStmt);
+
+            return node;
+        }
+
+        private readonly Stack<ExpressionSyntax> __exprs = new();
+
+        public override SyntaxNode VisitIsPatternExpression(IsPatternExpressionSyntax node)
+        {
+            if (node.Pattern is not DeclarationPatternSyntax declPatt
+                    || declPatt.Designation is not SingleVariableDesignationSyntax)
+            {
+                return node;
+            }
+
+            __exprs.Push(node.Expression);
+            var _ = (IsPatternExpressionSyntax)base.VisitIsPatternExpression(node);
+            __exprs.Pop();
+
+            return SyntaxFactory.BinaryExpression(
+                        SyntaxKind.IsExpression,
+                        node.Expression,
+                        declPatt.Type);
+        }
+    }
+}
+

--- a/src/SharpSyntaxRewriter/Rewriters/ExtractDeclarationFromPattern.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/ExtractDeclarationFromPattern.cs
@@ -28,6 +28,9 @@ namespace SharpSyntaxRewriter.Rewriters
             Debug.Assert(node.Designation is SingleVariableDesignationSyntax);
             var varDesig = (SingleVariableDesignationSyntax)node.Designation;
 
+            Debug.Assert(__exprs.Any());
+            var expr = __exprs.Peek();
+
             var declStmt =
                 SyntaxFactory.LocalDeclarationStatement(
                     SyntaxFactory.VariableDeclaration(
@@ -37,27 +40,11 @@ namespace SharpSyntaxRewriter.Rewriters
                                 varDesig.Identifier.WithoutTrivia(),
                                 null,
                                 SyntaxFactory.EqualsValueClause(
-                                    SyntaxFactory.DefaultExpression(node.Type))))));
-
-            Debug.Assert(__exprs.Any());
-            var expr = __exprs.Peek();
-
-            var ifStmt =
-                SyntaxFactory.IfStatement(
-                    SyntaxFactory.BinaryExpression(
-                        SyntaxKind.IsExpression,
-                        expr,
-                        node.Type),
-                    SyntaxFactory.ExpressionStatement(
-                        SyntaxFactory.AssignmentExpression(
-                            SyntaxKind.SimpleAssignmentExpression,
-                            SyntaxFactory.IdentifierName(varDesig.Identifier),
-                            SyntaxFactory.CastExpression(
-                                node.Type,
-                                expr))));
+                                    SyntaxFactory.CastExpression(
+                                        node.Type,
+                                        expr))))));
 
             _ctx.Peek().Add(declStmt);
-            _ctx.Peek().Add(ifStmt);
 
             return node;
         }

--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>SharpSyntaxRewriter</PackageId>
-    <PackageVersion>1.0.50</PackageVersion>
+    <PackageVersion>1.0.51</PackageVersion>
     <Authors>Leandro T. C. Melo</Authors>
     <Copyright>ShiftLeft Inc.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/tests/TestExtractDeclarationFromPattern.cs
+++ b/tests/TestExtractDeclarationFromPattern.cs
@@ -412,7 +412,7 @@ class CCC
 {
      private int FFF(object ppp)
      {
-         DateTime ddd = (DateTime)ppp; return ppp switch
+         object ddd = (object)ppp; return ppp switch
          {
              DateTime => 1,
              _ => 0,
@@ -531,10 +531,10 @@ class CCC
     private int SSS(string sss) { return 0; }
     private int FFF(object ppp)
     {
-        DateTime ddd = (DateTime)ppp; string sss = (string)ppp; return ppp switch
+        object ddd = (object)ppp; object sss = (object)ppp; return ppp switch
         {
-            DateTime => DDD(ddd),
-            string => SSS(sss),
+            DateTime => DDD((DateTime)ddd),
+            string => SSS((string)sss),
             _ => 0,
         };
     }
@@ -575,10 +575,10 @@ class CCC
     private int SSS(string sss) { return 0; }
     private int FFF(object ppp)
     {
-        return ppp switch
+        object uuu = (object)ppp; return ppp switch
         {
-            DateTime => DDD(uuu),
-            string => SSS(uuu),
+            DateTime => DDD((DateTime)uuu),
+            string => SSS((string)uuu),
             _ => 0,
         };
     }

--- a/tests/TestExtractDeclarationFromPattern.cs
+++ b/tests/TestExtractDeclarationFromPattern.cs
@@ -508,15 +508,17 @@ using System;
 
 class CCC
 {
-     private int FFF(object ppp)
-     {
-         return ppp switch
-         {
-             DateTime ddd => 1,
-             string sss => 1,
-             _ => 0,
-         };
-     }
+    private int DDD(DateTime ddd) { return 0; }
+    private int SSS(string sss) { return 0; }
+    private int FFF(object ppp)
+    {
+        return ppp switch
+        {
+            DateTime ddd => DDD(ddd),
+            string sss => SSS(sss),
+            _ => 0,
+        };
+    }
  }
 ";
 
@@ -525,15 +527,17 @@ using System;
 
 class CCC
 {
-     private int FFF(object ppp)
-     {
-         DateTime ddd = (DateTime)ppp; string sss = (string)ppp; return ppp switch
-         {
-             DateTime => 1,
-             string => 1,
-             _ => 0,
-         };
-     }
+    private int DDD(DateTime ddd) { return 0; }
+    private int SSS(string sss) { return 0; }
+    private int FFF(object ppp)
+    {
+        DateTime ddd = (DateTime)ppp; string sss = (string)ppp; return ppp switch
+        {
+            DateTime => DDD(ddd),
+            string => SSS(sss),
+            _ => 0,
+        };
+    }
  }
 ";
 
@@ -548,15 +552,17 @@ using System;
 
 class CCC
 {
-     private int FFF(object ppp)
-     {
-         return ppp switch
-         {
-             DateTime uuu => 1,
-             string uuu => 1,
-             _ => 0,
-         };
-     }
+    private int DDD(DateTime ddd) { return 0; }
+    private int SSS(string sss) { return 0; }
+    private int FFF(object ppp)
+    {
+        return ppp switch
+        {
+            DateTime uuu => DDD(uuu),
+            string uuu => SSS(uuu),
+            _ => 0,
+        };
+    }
  }
 ";
 
@@ -565,15 +571,17 @@ using System;
 
 class CCC
 {
-     private int FFF(object ppp)
-     {
-         return ppp switch
-         {
-             DateTime => 1,
-             string => 1,
-             _ => 0,
-         };
-     }
+    private int DDD(DateTime ddd) { return 0; }
+    private int SSS(string sss) { return 0; }
+    private int FFF(object ppp)
+    {
+        return ppp switch
+        {
+            DateTime => DDD(uuu),
+            string => SSS(uuu),
+            _ => 0,
+        };
+    }
  }
 ";
 

--- a/tests/TestExtractDeclarationFromPattern.cs
+++ b/tests/TestExtractDeclarationFromPattern.cs
@@ -1,0 +1,390 @@
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SharpSyntaxRewriter.Rewriters;
+using System;
+
+namespace Tests
+{
+    [TestClass]
+    public class TestExtractDeclarationFromPattern : RewriterTester
+    {
+        protected override SyntaxTree ApplyRewrite(SyntaxTree tree, Compilation compilation)
+        {
+            ExtractDeclarationFromPattern rw = new();
+            return rw.Apply(tree, compilation.GetSemanticModel(tree));
+        }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPattern1()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+    private void FFF(object ppp)
+    {
+        var vvv = ppp is DateTime ddd;
+    }
+}
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+    private void FFF(object ppp)
+    {
+        DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; var vvv = ppp is DateTime;
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPattern2()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+     public int Data;
+
+     private void FFF(object ppp)
+     {
+         var vvv = new CCC
+         {
+             Data = ppp is DateTime ddd ? 0 : 1
+         };
+     }
+ }
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+    public int Data;
+
+    private void FFF(object ppp)
+    {
+        DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; var vvv = new CCC
+        {
+            Data = ppp is DateTime ? 0 : 1
+        };
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPattern3()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+    private void GGG(DateTime ppp) {}
+    private void FFF(object ppp)
+    {
+        if (ppp is DateTime ddd)
+            GGG(ddd);
+    }
+}
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+    private void GGG(DateTime ppp) {}
+    private void FFF(object ppp)
+    {
+        DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; if (ppp is DateTime)
+            GGG(ddd);
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPattern4()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+    private void GGG(DateTime ppp) {}
+    private void FFF(object ppp)
+    {
+        if (true)
+            if (ppp is DateTime ddd)
+                GGG(ddd);
+    }
+}
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+    private void GGG(DateTime ppp) {}
+    private void FFF(object ppp)
+    {
+        if (true)
+        {   DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; if (ppp is DateTime)
+            GGG(ddd);   }
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPattern5()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+    private void GGG(DateTime ppp) {}
+    private void FFF(object ppp)
+    {
+        if (true)
+        {
+            if (ppp is DateTime ddd)
+                GGG(ddd);
+        }
+    }
+}
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+    private void GGG(DateTime ppp) {}
+    private void FFF(object ppp)
+    {
+        if (true)
+        {
+            DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; if (ppp is DateTime)
+            GGG(ddd);
+        }
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPattern6()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+    private void GGG(DateTime ppp) {}
+    private void FFF(object ppp)
+    {
+        if (true && ppp is DateTime ddd)
+            GGG(ddd);
+    }
+}
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+    private void GGG(DateTime ppp) {}
+    private void FFF(object ppp)
+    {
+        DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; if (true && ppp is DateTime)
+            GGG(ddd);
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPattern7()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+     public int Data;
+     private int GGG(DateTime ppp) { return 0; }
+     private void FFF(object ppp)
+     {
+         Data = ppp is DateTime ddd ? GGG(ddd) : 1;
+     }
+ }
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+    public int Data;
+    private int GGG(DateTime ppp) { return 0; }
+    private void FFF(object ppp)
+    {
+        DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; Data = ppp is DateTime ? GGG(ddd) : 1;
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPattern8()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+     public int Data;
+     private int GGG(DateTime ppp) { return 0; }
+     private void FFF(object ppp)
+     {
+         var vvv = new CCC
+         {
+             Data = ppp is DateTime ddd ? GGG(ddd) : 1
+         };
+     }
+ }
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+    public int Data;
+    private int GGG(DateTime ppp) { return 0; }
+    private void FFF(object ppp)
+    {
+        DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; var vvv = new CCC
+        {
+            Data = ppp is DateTime ? GGG(ddd) : 1
+        };
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPattern9()
+        {
+            var original = @"
+class CCC
+{
+    private void FFF(object ppp)
+    {
+        var vvv = ppp is null;
+    }
+}
+";
+
+            var expected = @"
+class CCC
+{
+    private void FFF(object ppp)
+    {
+        var vvv = ppp is null;
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPattern10()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+    static bool IsConferenceDay(DateTime date) => date is { Year: 2020, Month: 5, Day: 19 or 20 or 21 };
+}
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+    static bool IsConferenceDay(DateTime date) => date is { Year: 2020, Month: 5, Day: 19 or 20 or 21 };
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPattern11()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+     private void GGG(DateTime? ppp) { }
+
+     private void FFF(object ppp)
+     {
+         GGG(ppp is DateTime ddd ? ddd : null);
+     }
+ }
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+    private void GGG(DateTime? ppp) { }
+
+    private void FFF(object ppp)
+    {
+        DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; GGG(ppp is DateTime ? ddd : null);
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+    }
+}
+

--- a/tests/TestExtractDeclarationFromPattern.cs
+++ b/tests/TestExtractDeclarationFromPattern.cs
@@ -15,7 +15,7 @@ namespace Tests
         }
 
         [TestMethod]
-        public void TestExtractDeclarationFromPattern1()
+        public void TestExtractDeclarationFromPatternAsVarInitializer()
         {
             var original = @"
 using System;
@@ -45,7 +45,7 @@ class CCC
         }
 
         [TestMethod]
-        public void TestExtractDeclarationFromPattern2()
+        public void TestExtractDeclarationFromPatternAsObjectInitializer()
         {
             var original = @"
 using System;
@@ -85,7 +85,7 @@ class CCC
         }
 
         [TestMethod]
-        public void TestExtractDeclarationFromPattern3()
+        public void TestExtractDeclarationFromPatternInIfStatement()
         {
             var original = @"
 using System;
@@ -119,7 +119,7 @@ class CCC
         }
 
         [TestMethod]
-        public void TestExtractDeclarationFromPattern4()
+        public void TestExtractDeclarationFromPatternInIfStatementNested()
         {
             var original = @"
 using System;
@@ -155,7 +155,7 @@ class CCC
         }
 
         [TestMethod]
-        public void TestExtractDeclarationFromPattern5()
+        public void TestExtractDeclarationFromPatternInIfStatementNestedWithBlock()
         {
             var original = @"
 using System;
@@ -195,7 +195,7 @@ class CCC
         }
 
         [TestMethod]
-        public void TestExtractDeclarationFromPattern6()
+        public void TestExtractDeclarationFromPatternInIfStatmentWithLogicalAND()
         {
             var original = @"
 using System;
@@ -229,7 +229,7 @@ class CCC
         }
 
         [TestMethod]
-        public void TestExtractDeclarationFromPattern7()
+        public void TestExtractDeclarationFromPatternInConditionalExpression()
         {
             var original = @"
 using System;
@@ -263,7 +263,7 @@ class CCC
         }
 
         [TestMethod]
-        public void TestExtractDeclarationFromPattern8()
+        public void TestExtractDeclarationFromPatternInConditionalExpressionWithinObjectInitializer()
         {
             var original = @"
 using System;
@@ -303,7 +303,51 @@ class CCC
         }
 
         [TestMethod]
-        public void TestExtractDeclarationFromPattern9()
+        public void TestExtractDeclarationFromPatternInConditionalExpressionWithinObjectInitializerMultipleProperties()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+    public DateTime? DDD;
+    public string SSS;
+
+    private void FFF(object ppp)
+    {
+        var vvv = new CCC
+        {
+            DDD = ppp is DateTime ddd ? ddd : null,
+            SSS = ppp is string sss ? sss : "" ""
+        };
+    }
+}
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+    public DateTime? DDD;
+    public string SSS;
+
+    private void FFF(object ppp)
+    {
+        DateTime ddd = (DateTime)ppp; string sss = (string)ppp; var vvv = new CCC
+        {
+            DDD = ppp is DateTime ? ddd : null,
+            SSS = ppp is string ? sss : "" ""
+        };
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPatternKeepNullPattern()
         {
             var original = @"
 class CCC
@@ -329,7 +373,7 @@ class CCC
         }
 
         [TestMethod]
-        public void TestExtractDeclarationFromPattern10()
+        public void TestExtractDeclarationFromPatternKeepRangePattern()
         {
             var original = @"
 using System;
@@ -353,7 +397,7 @@ class CCC
         }
 
         [TestMethod]
-        public void TestExtractDeclarationFromPattern11()
+        public void TestExtractDeclarationFromPatternInConditionalExpressionAsArgument()
         {
             var original = @"
 using System;
@@ -387,7 +431,7 @@ class CCC
         }
 
         [TestMethod]
-        public void TestExtractDeclarationFromPattern12()
+        public void TestExtractDeclarationFromPatternInSwitchExpression()
         {
             var original = @"
 using System;
@@ -425,7 +469,7 @@ class CCC
         }
 
         [TestMethod]
-        public void TestExtractDeclarationFromPattern13()
+        public void TestExtractDeclarationFromPatternKeepSwitchArmWithoutDeclarationPattern()
         {
             var original = @"
 using System;
@@ -463,7 +507,7 @@ class CCC
         }
 
         [TestMethod]
-        public void TestExtractDeclarationFromPattern14()
+        public void TestExtractDeclarationFromPatternKeepUnderscorePattern()
         {
             var original = @"
 using System;
@@ -501,7 +545,7 @@ class CCC
         }
 
         [TestMethod]
-        public void TestExtractDeclarationFromPattern15()
+        public void TestExtractDeclarationFromPatternInSwitchExpressionWith2Arms()
         {
             var original = @"
 using System;
@@ -545,7 +589,7 @@ class CCC
         }
 
         [TestMethod]
-        public void TestExtractDeclarationFromPattern16()
+        public void TestExtractDeclarationFromPatternInSwitchExpressionWith2ArmsButDeclarationWithSameName()
         {
             var original = @"
 using System;
@@ -583,50 +627,6 @@ class CCC
         };
     }
  }
-";
-
-            TestRewrite_LinePreserve(original, expected);
-        }
-
-        [TestMethod]
-        public void TestExtractDeclarationFromPattern17()
-        {
-            var original = @"
-using System;
-
-class CCC
-{
-    public DateTime? DDD;
-    public string SSS;
-
-    private void FFF(object ppp)
-    {
-        var vvv = new CCC
-        {
-            DDD = ppp is DateTime ddd ? ddd : null,
-            SSS = ppp is string sss ? sss : "" ""
-        };
-    }
-}
-";
-
-            var expected = @"
-using System;
-
-class CCC
-{
-    public DateTime? DDD;
-    public string SSS;
-
-    private void FFF(object ppp)
-    {
-        DateTime ddd = (DateTime)ppp; string sss = (string)ppp; var vvv = new CCC
-        {
-            DDD = ppp is DateTime ? ddd : null,
-            SSS = ppp is string ? sss : "" ""
-        };
-    }
-}
 ";
 
             TestRewrite_LinePreserve(original, expected);

--- a/tests/TestExtractDeclarationFromPattern.cs
+++ b/tests/TestExtractDeclarationFromPattern.cs
@@ -36,7 +36,7 @@ class CCC
 {
     private void FFF(object ppp)
     {
-        DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; var vvv = ppp is DateTime;
+        DateTime ddd = (DateTime)ppp; var vvv = ppp is DateTime;
     }
 }
 ";
@@ -52,13 +52,13 @@ using System;
 
 class CCC
 {
-     public int Data;
+     public DateTime? Data;
 
      private void FFF(object ppp)
      {
          var vvv = new CCC
          {
-             Data = ppp is DateTime ddd ? 0 : 1
+             Data = ppp is DateTime ddd ? ddd : null
          };
      }
  }
@@ -69,13 +69,13 @@ using System;
 
 class CCC
 {
-    public int Data;
+    public DateTime? Data;
 
     private void FFF(object ppp)
     {
-        DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; var vvv = new CCC
+        DateTime ddd = (DateTime)ppp; var vvv = new CCC
         {
-            Data = ppp is DateTime ? 0 : 1
+            Data = ppp is DateTime ? ddd : null
         };
     }
 }
@@ -109,7 +109,7 @@ class CCC
     private void GGG(DateTime ppp) {}
     private void FFF(object ppp)
     {
-        DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; if (ppp is DateTime)
+        DateTime ddd = (DateTime)ppp; if (ppp is DateTime)
             GGG(ddd);
     }
 }
@@ -145,7 +145,7 @@ class CCC
     private void FFF(object ppp)
     {
         if (true)
-        {   DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; if (ppp is DateTime)
+        {   DateTime ddd = (DateTime)ppp; if (ppp is DateTime)
             GGG(ddd);   }
     }
 }
@@ -184,7 +184,7 @@ class CCC
     {
         if (true)
         {
-            DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; if (ppp is DateTime)
+            DateTime ddd = (DateTime)ppp; if (ppp is DateTime)
             GGG(ddd);
         }
     }
@@ -219,7 +219,7 @@ class CCC
     private void GGG(DateTime ppp) {}
     private void FFF(object ppp)
     {
-        DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; if (true && ppp is DateTime)
+        DateTime ddd = (DateTime)ppp; if (true && ppp is DateTime)
             GGG(ddd);
     }
 }
@@ -254,7 +254,7 @@ class CCC
     private int GGG(DateTime ppp) { return 0; }
     private void FFF(object ppp)
     {
-        DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; Data = ppp is DateTime ? GGG(ddd) : 1;
+        DateTime ddd = (DateTime)ppp; Data = ppp is DateTime ? GGG(ddd) : 1;
     }
 }
 ";
@@ -291,7 +291,7 @@ class CCC
     private int GGG(DateTime ppp) { return 0; }
     private void FFF(object ppp)
     {
-        DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; var vvv = new CCC
+        DateTime ddd = (DateTime)ppp; var vvv = new CCC
         {
             Data = ppp is DateTime ? GGG(ddd) : 1
         };
@@ -378,7 +378,7 @@ class CCC
 
     private void FFF(object ppp)
     {
-        DateTime ddd = default(DateTime); if (ppp is DateTime) ddd = (DateTime)ppp; GGG(ppp is DateTime ? ddd : null);
+        DateTime ddd = (DateTime)ppp; GGG(ppp is DateTime ? ddd : null);
     }
 }
 ";
@@ -412,7 +412,7 @@ class CCC
 {
      private int FFF(object ppp)
      {
-         DateTime ddd = default(DateTime); if(ppp is DateTime)ddd = (DateTime)ppp; return ppp switch
+         DateTime ddd = (DateTime)ppp; return ppp switch
          {
              DateTime => 1,
              _ => 0,
@@ -495,6 +495,130 @@ class CCC
          };
      }
  }
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPattern15()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+     private int FFF(object ppp)
+     {
+         return ppp switch
+         {
+             DateTime ddd => 1,
+             string sss => 1,
+             _ => 0,
+         };
+     }
+ }
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+     private int FFF(object ppp)
+     {
+         DateTime ddd = (DateTime)ppp; string sss = (string)ppp; return ppp switch
+         {
+             DateTime => 1,
+             string => 1,
+             _ => 0,
+         };
+     }
+ }
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPattern16()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+     private int FFF(object ppp)
+     {
+         return ppp switch
+         {
+             DateTime uuu => 1,
+             string uuu => 1,
+             _ => 0,
+         };
+     }
+ }
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+     private int FFF(object ppp)
+     {
+         return ppp switch
+         {
+             DateTime => 1,
+             string => 1,
+             _ => 0,
+         };
+     }
+ }
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPattern17()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+    public DateTime? DDD;
+    public string SSS;
+
+    private void FFF(object ppp)
+    {
+        var vvv = new CCC
+        {
+            DDD = ppp is DateTime ddd ? ddd : null,
+            SSS = ppp is string sss ? sss : "" ""
+        };
+    }
+}
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+    public DateTime? DDD;
+    public string SSS;
+
+    private void FFF(object ppp)
+    {
+        DateTime ddd = (DateTime)ppp; string sss = (string)ppp; var vvv = new CCC
+        {
+            DDD = ppp is DateTime ? ddd : null,
+            SSS = ppp is string ? sss : "" ""
+        };
+    }
+}
 ";
 
             TestRewrite_LinePreserve(original, expected);

--- a/tests/TestExtractDeclarationFromPattern.cs
+++ b/tests/TestExtractDeclarationFromPattern.cs
@@ -385,6 +385,120 @@ class CCC
 
             TestRewrite_LinePreserve(original, expected);
         }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPattern12()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+     private int FFF(object ppp)
+     {
+         return ppp switch
+         {
+             DateTime ddd => 1,
+             _ => 0,
+         };
+     }
+ }
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+     private int FFF(object ppp)
+     {
+         DateTime ddd = default(DateTime); if(ppp is DateTime)ddd = (DateTime)ppp; return ppp switch
+         {
+             DateTime => 1,
+             _ => 0,
+         };
+     }
+ }
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPattern13()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+     private int FFF(object ppp)
+     {
+         return ppp switch
+         {
+             DateTime => 1,
+             _ => 0,
+         };
+     }
+ }
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+     private int FFF(object ppp)
+     {
+         return ppp switch
+         {
+             DateTime => 1,
+             _ => 0,
+         };
+     }
+ }
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPattern14()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+     private int FFF(object ppp)
+     {
+         return ppp switch
+         {
+             DateTime _ => 1,
+             null => 0,
+         };
+     }
+ }
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+     private int FFF(object ppp)
+     {
+         return ppp switch
+         {
+             DateTime _ => 1,
+             null => 0,
+         };
+     }
+ }
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
     }
 }
 

--- a/tests/TestReplicateLocalInitialization.cs
+++ b/tests/TestReplicateLocalInitialization.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SharpSyntaxRewriter.Rewriters;
+
 namespace Tests
 {
     [TestClass]
@@ -2620,6 +2621,5 @@ class Aaa
 ";
             TestRewrite_LinePreserve(original, expected);
         }
-
     }
 }


### PR DESCRIPTION
This rewriter doesn't preserve exact semantics of the original syntax as a whole, but it does preserve that data flow relations from the original syntax.
There are 2 places in which a `DeclarationPattern` is being extracted:
- `is` expressions
- `switch` expressions