### PR TITLE
add (ignored) test in `foreach` expansion

### DIFF
--- a/tests/TestExpandForeach.cs
+++ b/tests/TestExpandForeach.cs
@@ -424,5 +424,35 @@ public class Abc
 
             TestRewrite_LinePreserve(original, expected);
         }
+
+        [TestMethod]
+        [Ignore] /*
+                  * Depends on a fix in Rolsyn or the C# specification.
+                  * https://github.com/dotnet/roslyn/issues/62747
+                  */
+        public void TestExpandForeachWithSpanTypeInsideAsyncMethod()
+        {
+            var original = @"
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+
+public class CCC
+{
+    public async Task MMM()
+    {
+        IReadOnlyList<string> lll = null;
+        foreach (ReadOnlySpan<char> ccc in lll)
+        {}
+    }
+}
+";
+
+            var expected = @"
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
     }
 }


### PR DESCRIPTION
The test is ignored until there's positioning about [this issue I opened in Roslyn](https://github.com/dotnet/roslyn/issues/62747).