### PR TITLE
fix addition of "spurious" braces inside `switch` sections

### DIFF
--- a/src/SharpSyntaxRewriter/Rewriters/ReplicateLocalInitialization.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/ReplicateLocalInitialization.cs
@@ -27,8 +27,7 @@ namespace SharpSyntaxRewriter.Rewriters
 
         private readonly Stack<List<StatementSyntax>> __ctx = new();
 
-        private SyntaxNode VisitStatements(SyntaxNode node,
-                                           SyntaxList<StatementSyntax> stmts)
+        private SyntaxList<StatementSyntax> VisitStatements(SyntaxList<StatementSyntax> stmts)
         {
             var replaceStmts = false;
             var stmts_P = SyntaxFactory.List<StatementSyntax>();
@@ -59,40 +58,26 @@ namespace SharpSyntaxRewriter.Rewriters
             }
 
             return replaceStmts
-                        ? SyntaxFactory.Block(stmts_P)
-                        : node;
+                        ? stmts_P
+                        : stmts;
         }
 
         public override SyntaxNode VisitBlock(BlockSyntax node)
         {
-            var node_P = (BlockSyntax)VisitStatements(node, node.Statements);
+            var stmts_P = VisitStatements(node.Statements);
 
-            return node_P.WithOpenBraceToken(node_P.OpenBraceToken
-                             .WithLeadingTrivia(node.OpenBraceToken.LeadingTrivia)
-                             .WithTrailingTrivia(node.OpenBraceToken.TrailingTrivia))
-                         .WithCloseBraceToken(node_P.CloseBraceToken
-                             .WithLeadingTrivia(node.CloseBraceToken.LeadingTrivia)
-                             .WithTrailingTrivia(node.CloseBraceToken.TrailingTrivia));
+            return stmts_P == node.Statements
+                    ? node
+                    : node.WithStatements(stmts_P);
         }
 
         public override SyntaxNode VisitSwitchSection(SwitchSectionSyntax node)
         {
-            var node_P = VisitStatements(node, node.Statements);
+            var stmts_P = VisitStatements(node.Statements);
 
-            if (node != node_P)
-            {
-                var blockNode = (BlockSyntax)node_P;
-                var lastStmt = blockNode.Statements.Last();
-                blockNode = blockNode.WithStatements(
-                    blockNode.Statements
-                             .Replace(lastStmt, lastStmt.WithoutTrailingTrivia()));
-
-                return node.WithStatements(
-                                SyntaxFactory.List<StatementSyntax>().Add(blockNode))
-                           .WithTriviaFrom(node);
-            }
-
-            return node;
+            return stmts_P == node.Statements
+                    ? node
+                    : node.WithStatements(stmts_P);
         }
 
         private SyntaxNode VisitUnscopedStatement(SyntaxNode node,

--- a/src/SharpSyntaxRewriter/Rewriters/ReplicateLocalInitialization.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/ReplicateLocalInitialization.cs
@@ -57,9 +57,8 @@ namespace SharpSyntaxRewriter.Rewriters
                 }
             }
 
-            return replaceStmts
-                        ? stmts_P
-                        : stmts;
+            return replaceStmts ? stmts_P
+                                : stmts;
         }
 
         public override SyntaxNode VisitBlock(BlockSyntax node)

--- a/src/SharpSyntaxRewriter/Rewriters/Types/StatementSynthesizerRewriter.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/Types/StatementSynthesizerRewriter.cs
@@ -40,8 +40,7 @@ namespace SharpSyntaxRewriter.Rewriters.Types
             return base.Visit(node);
         }
 
-        private SyntaxNode VisitStatements(SyntaxNode node,
-                                           SyntaxList<StatementSyntax> stmts)
+        private SyntaxList<StatementSyntax> VisitStatements(SyntaxList<StatementSyntax> stmts)
         {
             var replaceStmts = false;
             var stmts_P = SyntaxFactory.List<StatementSyntax>();
@@ -59,21 +58,17 @@ namespace SharpSyntaxRewriter.Rewriters.Types
                 stmts_P = stmts_P.Add((StatementSyntax)stmtP);
             }
 
-            return replaceStmts
-                        ? SyntaxFactory.Block(stmts_P)
-                        : node;
+            return replaceStmts ? stmts_P
+                                : stmts;
         }
 
         public override SyntaxNode VisitBlock(BlockSyntax node)
         {
-            var node_P = (BlockSyntax)VisitStatements(node, node.Statements);
+            var stmts_P = VisitStatements(node.Statements);
 
-            return node_P.WithOpenBraceToken(node_P.OpenBraceToken
-                             .WithLeadingTrivia(node.OpenBraceToken.LeadingTrivia)
-                             .WithTrailingTrivia(node.OpenBraceToken.TrailingTrivia))
-                         .WithCloseBraceToken(node_P.CloseBraceToken
-                             .WithLeadingTrivia(node.CloseBraceToken.LeadingTrivia)
-                             .WithTrailingTrivia(node.CloseBraceToken.TrailingTrivia));
+            return stmts_P == node.Statements
+                    ? node
+                    : node.WithStatements(stmts_P);
         }
 
         public override SyntaxNode VisitSwitchSection(SwitchSectionSyntax node)
@@ -81,11 +76,11 @@ namespace SharpSyntaxRewriter.Rewriters.Types
             // A `switch' section is "special" in the sense that it may contain
             // multiple statements that are not surrounded by a lexical block.
 
-            var node_P = VisitStatements(node, node.Statements);
+            var stmts_P = VisitStatements(node.Statements);
 
-            return node_P != node
-                        ? node.WithStatements(((BlockSyntax)node_P).Statements)
-                        : node;
+            return stmts_P == node.Statements
+                    ? node
+                    : node.WithStatements(stmts_P);
         }
     }
 }

--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>SharpSyntaxRewriter</PackageId>
-    <PackageVersion>1.0.53</PackageVersion>
+    <PackageVersion>1.0.54</PackageVersion>
     <Authors>Leandro T. C. Melo</Authors>
     <Copyright>ShiftLeft Inc.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/tests/TestReplicateLocalInitialization.cs
+++ b/tests/TestReplicateLocalInitialization.cs
@@ -2153,7 +2153,7 @@ public class Test
         }
 
         [TestMethod]
-        public void TestReplicateInitializationNoBlockSwitchSection()
+        public void TestReplicateInitializationInsideSwitchSectionWithoutBlock()
         {
             var original = @"
 using System;
@@ -2181,7 +2181,149 @@ public class Abc
         switch (111)
         {
             case 222:
-                { var rrr = new int[] { 99, 88 };rrr[0]=99;rrr[1]=88; }
+                var rrr = new int[] { 99, 88 }; rrr[0] = 99; rrr[1] = 88;
+        }
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestReplicateInitializationInsideSwitchSectionWithBlock()
+        {
+            var original = @"
+using System;
+
+public class Abc
+{
+    public void fff()
+    {
+        switch (111)
+        {
+            case 222:
+            {
+                var rrr = new int[] { 99, 88 };
+            }
+        }
+    }
+}
+";
+
+            var expected = @"
+using System;
+
+public class Abc
+{
+    public void fff()
+    {
+        switch (111)
+        {
+            case 222:
+            {
+                var rrr = new int[] { 99, 88 }; rrr[0] = 99; rrr[1] = 88;
+            }
+        }
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestReplicateLocalInitializationDontTouchSwitchSectionsWhenThereIsNoRewrite()
+        {
+            var original = @"
+public class CCC
+{
+    public void MMM(object ooo)
+    {
+        switch (ooo)
+        {
+            case string:
+                int jjj = 0;
+                if (true) {}
+                break;
+
+           case null:
+               jjj = 0;
+               if (true) {}
+               break;
+        }
+    }
+}
+";
+
+            var expected = @"
+public class CCC
+{
+    public void MMM(object ooo)
+    {
+        switch (ooo)
+        {
+            case string:
+                int jjj = 0;
+                if (true) {}
+                break;
+
+            case null:
+                jjj = 0;
+                if (true) {}
+                break;
+        }
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestReplicateLocalInitializationInsideSwitchSectionStatement()
+        {
+            var original = @"
+public class CCC
+{
+    private int VVV;
+
+    public void MMM(object ooo)
+    {
+        switch (ooo)
+        {
+            case string:
+                int jjj = 0;
+                if (true) { var nnn = new CCC() { VVV = 111 }; }
+                break;
+
+           case null:
+               jjj = 0;
+               if (true) { var mmm = new CCC() { VVV = 222 }; }
+               break;
+        }
+    }
+}
+";
+
+            var expected = @"
+public class CCC
+{
+    private int VVV;
+
+    public void MMM(object ooo)
+    {
+        switch (ooo)
+        {
+            case string:
+                int jjj = 0;
+                if (true) { var nnn = new CCC() { VVV = 111 }; nnn.VVV = 111 ; }
+                break;
+
+            case null:
+                jjj = 0;
+                if (true) { var mmm = new CCC() { VVV = 222 }; mmm.VVV = 222 ; }
+                break;
         }
     }
 }


### PR DESCRIPTION
Adding "spurious" braces (which didn't originally exist) in `switch` sections can break code as variables declared in one section can be used in another.
The change opportunely covered improved/simplified the visits of block sections too.