### PR TITLE
fix cast rewritten when extracting pattern decl. of type that is a type parameter

### DIFF
--- a/src/SharpSyntaxRewriter/Rewriters/ExtractDeclarationFromPattern.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/ExtractDeclarationFromPattern.cs
@@ -44,9 +44,22 @@ namespace SharpSyntaxRewriter.Rewriters
             Debug.Assert(__exprs.Any());
             var expr = __exprs.Peek();
 
-            var varTy = __patterns.Any()
-                ? SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword))
-                : varDesigTy;
+            TypeSyntax varTy;
+            ExpressionSyntax varExpr;
+            if (__patterns.Any())
+            {
+                varTy = SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.ObjectKeyword));
+                varExpr = expr;
+            }
+            else
+            {
+                varTy = varDesigTy;
+                varExpr =
+                    SyntaxFactory.CastExpression(
+                        SyntaxFactory.PredefinedType(
+                            SyntaxFactory.Token(SyntaxKind.ObjectKeyword)),
+                        expr);
+            }
 
             var declStmt =
                 SyntaxFactory.LocalDeclarationStatement(
@@ -59,7 +72,7 @@ namespace SharpSyntaxRewriter.Rewriters
                                 SyntaxFactory.EqualsValueClause(
                                     SyntaxFactory.CastExpression(
                                         varTy,
-                                        expr))))));
+                                        varExpr))))));
 
             _ctx.Peek().Add(declStmt);
         }
@@ -190,7 +203,12 @@ namespace SharpSyntaxRewriter.Rewriters
             if (varDesig.Identifier.Text != node.Identifier.Text)
                 return node;
 
-            return SyntaxFactory.CastExpression(pattType, node);
+            return SyntaxFactory.CastExpression(
+                pattType,
+                SyntaxFactory.CastExpression(
+                    SyntaxFactory.PredefinedType(
+                        SyntaxFactory.Token(SyntaxKind.ObjectKeyword)),
+                    node));
         }
     }
 }

--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>SharpSyntaxRewriter</PackageId>
-    <PackageVersion>1.0.54</PackageVersion>
+    <PackageVersion>1.0.55</PackageVersion>
     <Authors>Leandro T. C. Melo</Authors>
     <Copyright>ShiftLeft Inc.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/tests/TestExtractDeclarationFromPattern.cs
+++ b/tests/TestExtractDeclarationFromPattern.cs
@@ -36,13 +36,44 @@ class CCC
 {
     private void FFF(object ppp)
     {
-        DateTime ddd = (DateTime)ppp; var vvv = ppp is DateTime;
+        DateTime ddd = (DateTime)(object)ppp; var vvv = ppp is DateTime;
     }
 }
 ";
 
             TestRewrite_LinePreserve(original, expected);
         }
+
+        [TestMethod]
+        public void TestExtractDeclarationFromPatternAsVarInitializerAndTypeParameter()
+        {
+            var original = @"
+using System;
+
+class CCC
+{
+    private void FFF<TTT>(TTT ppp)
+    {
+        var vvv = ppp is DateTime ddd;
+    }
+}
+";
+
+            var expected = @"
+using System;
+
+class CCC
+{
+    private void FFF<TTT>(TTT ppp)
+    {
+        DateTime ddd = (DateTime)(object)ppp; var vvv = ppp is DateTime;
+    }
+}
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
 
         [TestMethod]
         public void TestExtractDeclarationFromPatternAsObjectInitializer()
@@ -73,7 +104,7 @@ class CCC
 
     private void FFF(object ppp)
     {
-        DateTime ddd = (DateTime)ppp; var vvv = new CCC
+        DateTime ddd = (DateTime)(object)ppp; var vvv = new CCC
         {
             Data = ppp is DateTime ? ddd : null
         };
@@ -109,7 +140,7 @@ class CCC
     private void GGG(DateTime ppp) {}
     private void FFF(object ppp)
     {
-        DateTime ddd = (DateTime)ppp; if (ppp is DateTime)
+        DateTime ddd = (DateTime)(object)ppp; if (ppp is DateTime)
             GGG(ddd);
     }
 }
@@ -145,7 +176,7 @@ class CCC
     private void FFF(object ppp)
     {
         if (true)
-        {   DateTime ddd = (DateTime)ppp; if (ppp is DateTime)
+        {   DateTime ddd = (DateTime)(object)ppp; if (ppp is DateTime)
             GGG(ddd);   }
     }
 }
@@ -184,7 +215,7 @@ class CCC
     {
         if (true)
         {
-            DateTime ddd = (DateTime)ppp; if (ppp is DateTime)
+            DateTime ddd = (DateTime)(object)ppp; if (ppp is DateTime)
             GGG(ddd);
         }
     }
@@ -219,7 +250,7 @@ class CCC
     private void GGG(DateTime ppp) {}
     private void FFF(object ppp)
     {
-        DateTime ddd = (DateTime)ppp; if (true && ppp is DateTime)
+        DateTime ddd = (DateTime)(object)ppp; if (true && ppp is DateTime)
             GGG(ddd);
     }
 }
@@ -254,7 +285,7 @@ class CCC
     private int GGG(DateTime ppp) { return 0; }
     private void FFF(object ppp)
     {
-        DateTime ddd = (DateTime)ppp; Data = ppp is DateTime ? GGG(ddd) : 1;
+        DateTime ddd = (DateTime)(object)ppp; Data = ppp is DateTime ? GGG(ddd) : 1;
     }
 }
 ";
@@ -291,7 +322,7 @@ class CCC
     private int GGG(DateTime ppp) { return 0; }
     private void FFF(object ppp)
     {
-        DateTime ddd = (DateTime)ppp; var vvv = new CCC
+        DateTime ddd = (DateTime)(object)ppp; var vvv = new CCC
         {
             Data = ppp is DateTime ? GGG(ddd) : 1
         };
@@ -334,7 +365,7 @@ class CCC
 
     private void FFF(object ppp)
     {
-        DateTime ddd = (DateTime)ppp; string sss = (string)ppp; var vvv = new CCC
+        DateTime ddd = (DateTime)(object)ppp; string sss = (string)(object)ppp; var vvv = new CCC
         {
             DDD = ppp is DateTime ? ddd : null,
             SSS = ppp is string ? sss : "" ""
@@ -422,7 +453,7 @@ class CCC
 
     private void FFF(object ppp)
     {
-        DateTime ddd = (DateTime)ppp; GGG(ppp is DateTime ? ddd : null);
+        DateTime ddd = (DateTime)(object)ppp; GGG(ppp is DateTime ? ddd : null);
     }
 }
 ";
@@ -577,8 +608,8 @@ class CCC
     {
         object ddd = (object)ppp; object sss = (object)ppp; return ppp switch
         {
-            DateTime => DDD((DateTime)ddd),
-            string => SSS((string)sss),
+            DateTime => DDD((DateTime)(object)ddd),
+            string => SSS((string)(object)sss),
             _ => 0,
         };
     }
@@ -621,8 +652,8 @@ class CCC
     {
         object uuu = (object)ppp; return ppp switch
         {
-            DateTime => DDD((DateTime)uuu),
-            string => SSS((string)uuu),
+            DateTime => DDD((DateTime)(object)uuu),
+            string => SSS((string)(object)uuu),
             _ => 0,
         };
     }
@@ -660,8 +691,8 @@ public class CCC
     {
         object sss = (object)ppp; return ppp switch
         {
-            string { Length: >= 5 } => (string)sss.Substring(0, 5),
-            string => (string)sss,
+            string { Length: >= 5 } => (string)(object)sss.Substring(0, 5),
+            string => (string)(object)sss,
         };
     }
 }
@@ -698,8 +729,8 @@ public class CCC
     {
         object sss = (object)ppp; object qqq = (object)ppp; return ppp switch
         {
-            string { Length: >= 5 } => (string)sss.Substring(0, 5),
-            string => (string)qqq,
+            string { Length: >= 5 } => (string)(object)sss.Substring(0, 5),
+            string => (string)(object)qqq,
         };
     }
 }


### PR DESCRIPTION
When the type of the pattern is a type parameter (eg `void f<T>(T p) { }`), it can't be directly cast to another type. So I'm introducing an intermediate cast to `object` type (to all cases, as this cast is safe and preserve uniformity of every rewrite) to ensure that casts are correct.