### PR TITLE
unparameterize record's ctor parameters lists even if empty

### DIFF
--- a/src/SharpSyntaxRewriter/Rewriters/UnparameterizeRecordDeclaration.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/UnparameterizeRecordDeclaration.cs
@@ -26,8 +26,7 @@ namespace SharpSyntaxRewriter.Rewriters
             if (ModifiersChecker.Has_abstract(node.Modifiers))
                 return node;
 
-            if (node.ParameterList == null
-                    || !node.ParameterList.Parameters.Any())
+            if (node.ParameterList == null)
                 return node;
 
             var node_P = node.WithModifiers(

--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>SharpSyntaxRewriter</PackageId>
-    <PackageVersion>1.0.56</PackageVersion>
+    <PackageVersion>1.0.57</PackageVersion>
     <Authors>Leandro T. C. Melo</Authors>
     <Copyright>ShiftLeft Inc.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/tests/TestUnparameterizeRecordDeclaration.cs
+++ b/tests/TestUnparameterizeRecordDeclaration.cs
@@ -215,7 +215,7 @@ public record Teacher
         }
 
         [TestMethod]
-        public void TEMP()
+        public void TestUnparameterizeRecordDeclarationEmptyParameterWithNonEmptyParameterAbstractBase()
         {
             var original = @"
 public abstract record Person(int ppp);
@@ -233,7 +233,7 @@ public record Teacher
         }
 
         [TestMethod]
-        public void TEMP2()
+        public void TestUnparameterizeRecordDeclarationEmptyParameterWithNonEmptyParameterBase()
         {
             var original = @"
 public record Person(int ppp);

--- a/tests/TestUnparameterizeRecordDeclaration.cs
+++ b/tests/TestUnparameterizeRecordDeclaration.cs
@@ -213,5 +213,42 @@ public record Teacher
 
             TestRewrite_LinePreserve(original, expected);
         }
+
+        [TestMethod]
+        public void TEMP()
+        {
+            var original = @"
+public abstract record Person(int ppp);
+public record Teacher()
+    : Person(1);
+";
+
+            var expected = @"
+public abstract record Person(int ppp);
+public record Teacher
+    : Person { public Teacher() : base(1) {} }
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TEMP2()
+        {
+            var original = @"
+public record Person(int ppp);
+public record Teacher()
+    : Person(1);
+";
+
+            var expected = @"
+public record Person { public int ppp {get;init;} public Person(int ppp) { this.ppp=ppp; }}
+public record Teacher
+    : Person { public Teacher() : base(1) {} }
+";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
     }
 }


### PR DESCRIPTION
it may inherit from a base record with a non-empty parameter list

fix for https://github.com/ShiftLeftSecurity/product/issues/11050