### PR TITLE
C#11 - Renames file-local types

### DIFF
--- a/src/SharpSyntaxRewriter/Rewriters/RenameFileScopedType.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/RenameFileScopedType.cs
@@ -73,21 +73,7 @@ namespace SharpSyntaxRewriter.Rewriters
         {
             return VisitTypeDeclaration(node, _ => base.VisitRecordDeclaration(_) as RecordDeclarationSyntax);
         }
-
-        public override SyntaxNode VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
-        {
-            var node_P = base.VisitObjectCreationExpression(node) as ObjectCreationExpressionSyntax;
-
-            var objTypeSym = _semaModel.GetTypeInfo(node).ConvertedType as INamedTypeSymbol;
-
-            if (objTypeSym?.IsFileLocal ?? false)
-            {
-                return node_P.WithType(SyntaxFactory.ParseTypeName(SynthesizedTypeName(objTypeSym)).WithLeadingTrivia(node.Type.GetLeadingTrivia()).WithTrailingTrivia(node.Type.GetTrailingTrivia()));
-            }
-
-            return node_P;
-        }
-
+        
         public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node)
         {
             var node_P = base.VisitIdentifierName(node) as IdentifierNameSyntax;
@@ -95,7 +81,7 @@ namespace SharpSyntaxRewriter.Rewriters
             if (node.IsVar)
                 return node_P;
             
-            var nodeSym = _semaModel.GetTypeInfo(node).Type as INamedTypeSymbol;
+            var nodeSym = _semaModel.GetSymbolInfo(node).Symbol as INamedTypeSymbol;
 
             if (!(nodeSym?.IsFileLocal ?? false))
                 return node_P;

--- a/src/SharpSyntaxRewriter/Rewriters/RenameFileScopedType.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/RenameFileScopedType.cs
@@ -1,0 +1,113 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using SharpSyntaxRewriter.Rewriters.Types;
+using System;
+using System.Linq;
+
+namespace SharpSyntaxRewriter.Rewriters
+{
+    public class RenameFileScopedType : SymbolicRewriter
+    {
+        public const string ID = "<rename file-scoped type>";
+
+        public override string Name()
+        {
+            return ID;
+        }
+        
+        private static string SynthesizedTypeName(ISymbol namedTypeSymbol)
+        {
+            return namedTypeSymbol.MetadataName
+                .Replace('<', '_')
+                .Replace('>', '_')
+                .Replace('`', '_');
+        }
+
+        private SyntaxNode VisitTypeDeclaration<T>(T node, Func<T, T> visit) where T : BaseTypeDeclarationSyntax
+        {
+            var node_P = visit(node);
+            var nodeSym = _semaModel.GetDeclaredSymbol(node);
+            
+            if (nodeSym?.IsFileLocal ?? false)
+            {
+                var fileModifierToken = node_P.Modifiers.Single(token => token.IsKind(SyntaxKind.FileKeyword));
+                
+                var newIdentifier = SyntaxFactory.Identifier(SynthesizedTypeName(nodeSym))
+                    .WithLeadingTrivia(node_P.Identifier.LeadingTrivia)
+                    .WithTrailingTrivia(node_P.Identifier.TrailingTrivia);
+
+                var internalModifierToken = SyntaxFactory.Token(SyntaxKind.InternalKeyword)
+                    .WithLeadingTrivia(fileModifierToken.LeadingTrivia)
+                    .WithTrailingTrivia(fileModifierToken.TrailingTrivia);
+
+                var newModifiersList = node_P.Modifiers.Replace(fileModifierToken, internalModifierToken);
+
+                return node_P.WithIdentifier(newIdentifier).WithModifiers(newModifiersList);
+            }
+
+            return node_P;
+        }
+        
+        public override SyntaxNode VisitClassDeclaration(ClassDeclarationSyntax node)
+        {
+            return VisitTypeDeclaration(node, _ => base.VisitClassDeclaration(_) as ClassDeclarationSyntax);
+        }
+
+        public override SyntaxNode VisitStructDeclaration(StructDeclarationSyntax node)
+        {
+            return VisitTypeDeclaration(node, _ => base.VisitStructDeclaration(_) as StructDeclarationSyntax);
+        }
+
+        public override SyntaxNode VisitInterfaceDeclaration(InterfaceDeclarationSyntax node)
+        {
+            return VisitTypeDeclaration(node, _ => base.VisitInterfaceDeclaration(_) as InterfaceDeclarationSyntax);
+        }
+
+        public override SyntaxNode VisitEnumDeclaration(EnumDeclarationSyntax node)
+        {
+            return VisitTypeDeclaration(node, _ => base.VisitEnumDeclaration(_) as EnumDeclarationSyntax);
+        }
+
+        public override SyntaxNode VisitRecordDeclaration(RecordDeclarationSyntax node)
+        {
+            return VisitTypeDeclaration(node, _ => base.VisitRecordDeclaration(_) as RecordDeclarationSyntax);
+        }
+
+        public override SyntaxNode VisitObjectCreationExpression(ObjectCreationExpressionSyntax node)
+        {
+            var node_P = base.VisitObjectCreationExpression(node) as ObjectCreationExpressionSyntax;
+
+            var objTypeSym = _semaModel.GetTypeInfo(node).ConvertedType as INamedTypeSymbol;
+
+            if (objTypeSym?.IsFileLocal ?? false)
+            {
+                return node_P.WithType(SyntaxFactory.ParseTypeName(SynthesizedTypeName(objTypeSym)).WithLeadingTrivia(node.Type.GetLeadingTrivia()).WithTrailingTrivia(node.Type.GetTrailingTrivia()));
+            }
+
+            return node_P;
+        }
+
+        public override SyntaxNode VisitIdentifierName(IdentifierNameSyntax node)
+        {
+            var node_P = base.VisitIdentifierName(node) as IdentifierNameSyntax;
+
+            if (node.IsVar)
+                return node_P;
+            
+            var nodeSym = _semaModel.GetTypeInfo(node).Type as INamedTypeSymbol;
+
+            if (!(nodeSym?.IsFileLocal ?? false))
+                return node_P;
+
+            if (nodeSym.Name != node.Identifier.Text)
+                return node_P;
+
+            var newIdentifier = SyntaxFactory.ParseToken(SynthesizedTypeName(nodeSym))
+                .WithLeadingTrivia(node_P.GetLeadingTrivia())
+                .WithTrailingTrivia(node_P.GetTrailingTrivia());
+
+            return node_P.WithIdentifier(newIdentifier);
+        }
+    }
+}

--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -42,7 +42,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
   </ItemGroup>
 
   <ProjectExtensions>

--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>SharpSyntaxRewriter</PackageId>
-    <PackageVersion>1.0.57</PackageVersion>
+    <PackageVersion>1.0.58</PackageVersion>
     <Authors>Leandro T. C. Melo</Authors>
     <Copyright>ShiftLeft Inc.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/tests/TestRenameFileScopedType.cs
+++ b/tests/TestRenameFileScopedType.cs
@@ -197,6 +197,10 @@ internal class __FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B8
 
         [DataTestMethod]
         [DataRow("class")]
+        [DataRow("struct")]
+        [DataRow("record")]
+        [DataRow("enum")]
+        [DataRow("interface")]
         public void TestOccurrenceOfFileScopedTypeInCastingExpression(string declKind)
         {
             var original = $@"
@@ -212,7 +216,7 @@ file class Program
 
     void M()
     {{
-        N((I) null);
+        N((I) default);
     }}
 }}";
 
@@ -229,7 +233,7 @@ internal class __FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B8
 
     void M()
     {{
-        N((__FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__I) null);
+        N((__FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__I) default);
     }}
 }}";
             

--- a/tests/TestRenameFileScopedType.cs
+++ b/tests/TestRenameFileScopedType.cs
@@ -1,0 +1,239 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SharpSyntaxRewriter.Rewriters;
+
+namespace Tests
+{
+    [TestClass]
+    public class TestRenameFileScopedType : RewriterTester
+    {
+        protected override SyntaxTree ApplyRewrite(SyntaxTree tree, Compilation compilation)
+        {
+            var rw = new RenameFileScopedType();
+            return rw.Apply(tree, compilation.GetSemanticModel(tree));
+        }
+
+        [DataTestMethod]
+        [DataRow("class")]
+        [DataRow("interface")]
+        [DataRow("enum")]
+        [DataRow("struct")]
+        [DataRow("record")]
+        public void TestEmptyFileScopedTypeDeclaration(string declKind)
+        {
+            var original = $@"
+using System;
+file {declKind} C
+{{
+}}";
+
+            var expected = $@"
+using System;
+internal {declKind} __FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__C
+{{
+}}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [DataTestMethod]
+        [DataRow("class")]
+        [DataRow("interface")]
+        [DataRow("struct")]
+        [DataRow("record")]
+        public void TestEmptyGenericFileScopedTypeDeclaration(string declKind)
+        {
+            var original = $@"
+using System.Collections;
+file {declKind} C<T> where T : IEnumerable
+{{
+}}";
+
+            var expected = $@"
+using System.Collections;
+internal {declKind} __FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__C_1<T> where T : IEnumerable
+{{
+}}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+
+        [DataTestMethod]
+        [DataRow("class")]
+        [DataRow("interface")]
+        [DataRow("struct")]
+        [DataRow("record")]
+        public void TestFileScopedTypeDeclarationWithMemberMethodReturningItsType(string declKind)
+        {
+            var original = $@"
+file {declKind} C
+{{
+    public static C Create()
+    {{
+        return default;
+    }}
+}}";
+
+            var expected = $@"
+internal {declKind} __FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__C
+{{
+    public static __FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__C Create()
+    {{
+        return default;
+    }}
+}}";
+
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestObjectCreationOfFileScopedClassDeclaration()
+        {
+            var original = @"
+file class C
+{
+}
+
+public class Program
+{
+    void M()
+    {
+        var x = new C();
+    }
+}";
+
+            var expected = @"
+internal class __FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__C
+{
+}
+
+public class Program
+{
+    void M()
+    {
+        var x = new __FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__C();
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestClassDeclarationExtendingFileScopedInterface()
+        {
+            var original = @"
+file interface I
+{
+}
+public class C : I
+{
+}
+";
+            var expected = @"
+internal interface __FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__I
+{
+}
+public class C : __FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__I
+{
+}
+";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestOccurenceOfFileScopedTypeAsTypeParameter()
+        {
+            var original = @"
+using System.Collections.Generic;
+file interface I
+{
+}
+file class Program
+{
+    private List<I> ListField;
+}
+";
+            var expected = @"
+using System.Collections.Generic;
+internal interface __FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__I
+{
+}
+internal class __FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__Program
+{
+    private List<__FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__I> ListField;
+}
+";
+            TestRewrite_LinePreserve(original, expected);
+
+
+        }
+
+        [DataTestMethod]
+        [DataRow("class")]
+        [DataRow("interface")]
+        [DataRow("struct")]
+        [DataRow("record")]
+        [DataRow("enum")]
+        public void TestOccurrenceOfFileScopedTypeInFieldDeclaration(string declKind)
+        {
+            var original = $@"
+file {declKind} I
+{{
+}}
+file class Program
+{{
+    private I SomeField;
+}}
+";
+            var expected = $@"
+internal {declKind} __FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__I
+{{
+}}
+internal class __FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__Program
+{{
+    private __FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__I SomeField;
+}}
+";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [DataTestMethod]
+        [DataRow("class")]
+        public void TestOccurrenceOfFileScopedTypeInCastingExpression(string declKind)
+        {
+            var original = $@"
+file {declKind} I
+{{
+}}
+file class Program
+{{
+    void N(I arg)
+    {{
+        System.Console.WriteLine(arg.ToString());
+    }}
+
+    void M()
+    {{
+        N((I) null);
+    }}
+}}";
+
+            var expected = $@"
+internal {declKind} __FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__I
+{{
+}}
+internal class __FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__Program
+{{
+    void N(__FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__I arg)
+    {{
+        System.Console.WriteLine(arg.ToString());
+    }}
+
+    void M()
+    {{
+        N((__FE3B0C44298FC1C149AFBF4C8996FB92427AE41E4649B934CA495991B7852B855__I) null);
+    }}
+}}";
+            
+            TestRewrite_LinePreserve(original, expected);
+        }
+    }
+}

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -11,7 +11,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This patch renames class/interface/enum/struct/record declarations annotated with the `file` modifier.

The rewrite step is similar to that observed on SharpLab ([example](https://sharplab.io/#v2:EYLgtghglgdgNAExAagD4DMoBsCmACAAQCY8BJAWACgBvKgXys1zwGcAXAJwFcBjNvAMLUGlIA==)), except with invalid characters replaced by an underscore (_).

References:
* https://learn.microsoft.com/en-gb/dotnet/csharp/language-reference/keywords/file
* https://learn.microsoft.com/en-gb/dotnet/csharp/language-reference/proposals/csharp-11.0/file-local-types



