### PR TITLE
Support for C#11 list pattern expressions

### DIFF
--- a/src/SharpSyntaxRewriter/Rewriters/LowerIsListPatternExpression.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/LowerIsListPatternExpression.cs
@@ -1,0 +1,194 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using SharpSyntaxRewriter.Rewriters.Types;
+using System;
+using System.Linq;
+
+namespace SharpSyntaxRewriter.Rewriters
+{
+    public class LowerIsListPatternExpression : SymbolicRewriter
+    {
+        public const string ID = "<lower `is' list pattern expression>";
+        
+        public override string Name()
+        {
+            return ID;
+        }
+        
+        public override SyntaxNode VisitIsPatternExpression(IsPatternExpressionSyntax node)
+        {
+            if (node.Pattern is ListPatternSyntax)
+            {
+                return new ListPatternLowererVisitor(_semaModel).Visit(node.Pattern)(node.Expression);
+            }
+
+            return base.VisitIsPatternExpression(node);
+        }
+    }
+
+    internal class ListPatternLowererVisitor : CSharpSyntaxVisitor<Func<ExpressionSyntax,ExpressionSyntax>>
+    {
+        private readonly SemanticModel __semanticModel;
+
+        public ListPatternLowererVisitor(SemanticModel semanticModel)
+        {
+            __semanticModel = semanticModel;
+        }
+        
+        public override Func<ExpressionSyntax, ExpressionSyntax> VisitConstantPattern(ConstantPatternSyntax node)
+        {
+            var constantsTypeSym = __semanticModel.GetTypeInfo(node.Expression).Type;
+            
+            // If we can't find the constant's type, return `is <constant>`. 
+            if (constantsTypeSym is null)
+            {
+                return holeExpr => SyntaxFactory.IsPatternExpression(holeExpr, node);
+            }
+
+            var constantsTypeSyntax = SyntaxFactory.ParseTypeName(constantsTypeSym.ToString());
+            
+            return holeExpr => SyntaxFactory.BinaryExpression(SyntaxKind.EqualsExpression,
+                SyntaxFactory.CastExpression(constantsTypeSyntax, holeExpr),
+                node.Expression);
+        }
+        
+        public override Func<ExpressionSyntax, ExpressionSyntax> VisitTypePattern(TypePatternSyntax node)
+        {
+            return holeExpr => SyntaxFactory.IsPatternExpression(holeExpr, node);
+        }
+        
+        public override Func<ExpressionSyntax, ExpressionSyntax> VisitRecursivePattern(RecursivePatternSyntax node)
+        {
+            return holeExpr => SyntaxFactory.IsPatternExpression(holeExpr, node);
+        }
+
+        public override Func<ExpressionSyntax, ExpressionSyntax> VisitParenthesizedPattern(ParenthesizedPatternSyntax node)
+        {
+            var nodePat = Visit(node.Pattern);
+            
+            return holeExpr => SyntaxFactory.ParenthesizedExpression(nodePat(holeExpr));
+        }
+
+        public override Func<ExpressionSyntax, ExpressionSyntax> VisitUnaryPattern(UnaryPatternSyntax node)
+        {
+            var nodePat = Visit(node.Pattern);
+            
+            return node.OperatorToken.Kind() switch
+            {
+                SyntaxKind.NotKeyword => holeExpr => SyntaxFactory.PrefixUnaryExpression(SyntaxKind.LogicalNotExpression, SyntaxFactory.ParenthesizedExpression(nodePat(holeExpr))),
+            };
+        }
+
+        public override Func<ExpressionSyntax, ExpressionSyntax> VisitVarPattern(VarPatternSyntax node)
+        {
+            // Small optimization: `var _` is treated the same way as `_`
+            if (node.Designation is DiscardDesignationSyntax)
+            {
+                return _ => SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression);
+            }
+            
+            return holeExpr => SyntaxFactory.IsPatternExpression(holeExpr, node);
+        }
+
+        public override Func<ExpressionSyntax, ExpressionSyntax> VisitSlicePattern(SlicePatternSyntax node)
+        {
+            return node.Pattern switch
+            {
+                // Small optimization: `..var _` is treated the same way as `.. _`
+                null or DiscardPatternSyntax or VarPatternSyntax{Designation:DiscardDesignationSyntax} => _ => SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression),
+                RecursivePatternSyntax recPat => holeExpr => SyntaxFactory.IsPatternExpression(holeExpr, recPat),
+                VarPatternSyntax varPat => holeExpr => SyntaxFactory.IsPatternExpression(holeExpr, varPat)
+            };
+        }
+
+        public override Func<ExpressionSyntax, ExpressionSyntax> VisitDiscardPattern(DiscardPatternSyntax node)
+        {
+            return _ => SyntaxFactory.LiteralExpression(SyntaxKind.TrueLiteralExpression);
+        }
+
+        public override Func<ExpressionSyntax, ExpressionSyntax> VisitBinaryPattern(BinaryPatternSyntax node)
+        {
+            var lhsPat = Visit(node.Left);
+            var rhsPat = Visit(node.Right);
+            
+            return node.OperatorToken.Kind() switch
+            {
+                SyntaxKind.OrKeyword => holeExpr => SyntaxFactory.BinaryExpression(SyntaxKind.LogicalOrExpression, lhsPat(holeExpr), rhsPat(holeExpr)),
+                SyntaxKind.AndKeyword => holeExpr => SyntaxFactory.BinaryExpression(SyntaxKind.LogicalAndExpression, lhsPat(holeExpr), rhsPat(holeExpr)),
+            };
+        }
+
+        public override Func<ExpressionSyntax, ExpressionSyntax> VisitRelationalPattern(RelationalPatternSyntax node)
+        {
+            SyntaxKind BinOpKind(SyntaxToken opToken) => opToken.Kind() switch
+            {
+                SyntaxKind.GreaterThanToken => SyntaxKind.GreaterThanExpression,
+                SyntaxKind.GreaterThanEqualsToken => SyntaxKind.GreaterThanOrEqualExpression,
+                SyntaxKind.LessThanToken => SyntaxKind.LessThanExpression,
+                SyntaxKind.LessThanEqualsToken => SyntaxKind.LessThanOrEqualExpression
+            };
+            
+            return holeExpr => SyntaxFactory.BinaryExpression(BinOpKind(node.OperatorToken), holeExpr, node.Expression);
+        }
+
+        public override Func<ExpressionSyntax, ExpressionSyntax> VisitListPattern(ListPatternSyntax node)
+        {
+            var sliceIndex = node.Patterns.IndexOf(pattern => pattern is SlicePatternSyntax);
+            var hasSlice = sliceIndex > -1;
+            var patterns = node.Patterns.Select((pattern, index) => LowerListElementPattern(pattern, index, sliceIndex, node.Patterns.Count));
+
+            ExpressionSyntax NotNullSyntax(ExpressionSyntax expr) => 
+                SyntaxFactory.BinaryExpression(SyntaxKind.NotEqualsExpression, expr, SyntaxFactory.LiteralExpression(SyntaxKind.NullLiteralExpression));
+
+            ExpressionSyntax HasLengthOrCountSyntax(ExpressionSyntax expr) =>
+                SyntaxFactory.BinaryExpression(hasSlice ? SyntaxKind.GreaterThanOrEqualExpression : SyntaxKind.EqualsExpression,
+                    SyntaxFactory.MemberAccessExpression(SyntaxKind.SimpleMemberAccessExpression, expr, SyntaxFactory.IdentifierName(GetSuitableLengthOrCountPropertyName(node))),
+                    SyntaxFactory.ParseExpression((node.Patterns.Count - (hasSlice ? 1 : 0)).ToString()));
+
+            ExpressionSyntax AndSyntax(ExpressionSyntax lhs, ExpressionSyntax rhs) => rhs switch
+            {
+                // Small optimization: `lhs && (true)` becomes `lhs`
+                ParenthesizedExpressionSyntax { Expression: LiteralExpressionSyntax lit } when lit.IsKind(SyntaxKind.TrueLiteralExpression) => lhs,
+                _ => SyntaxFactory.BinaryExpression(SyntaxKind.LogicalAndExpression, lhs, rhs)
+            };
+
+            return holeExpr => patterns
+                .Select(pattern => pattern(holeExpr))
+                .Select(SyntaxFactory.ParenthesizedExpression)
+                .Aggregate(AndSyntax(NotNullSyntax(holeExpr), HasLengthOrCountSyntax(holeExpr)), AndSyntax);
+        }
+
+        private string GetSuitableLengthOrCountPropertyName(ListPatternSyntax node)
+        {
+            return __semanticModel.GetTypeInfo(node).Type?.GetMembers()
+                       .OfType<IPropertySymbol>()
+                       .Where(propSym => propSym.Type.Name == "Int32")
+                       .Where(propSym => propSym.Name is "Length" or "Count")
+                       .Select(propSym => propSym.Name)
+                       .FirstOrDefault()
+                   ?? "Length";
+        }
+
+        private Func<ExpressionSyntax, ExpressionSyntax> LowerListElementPattern(PatternSyntax currentPattern, int currentIndex, int sliceIndex, int listLength)
+        {
+            var currentPat = Visit(currentPattern);
+            
+            ExpressionSyntax ElemIndexSyntax(ExpressionSyntax expr)
+            {
+                var indexStr = sliceIndex switch
+                {
+                    <0 => $"{currentIndex}",
+                    >=0 when currentIndex < sliceIndex => $"{currentIndex}",
+                    >=0 when currentIndex == sliceIndex => $"{currentIndex}..^{listLength - sliceIndex -1}",
+                    >=0 when currentIndex > sliceIndex => $"^{listLength - currentIndex}"
+                };
+                
+                return SyntaxFactory.ElementAccessExpression(expr, SyntaxFactory.ParseBracketedArgumentList($"[{indexStr}]"));
+            }
+            
+            return holeExpr => currentPat(ElemIndexSyntax(holeExpr));
+        }
+    }
+    
+}

--- a/tests/TestLowerIsListPatternExpression.cs
+++ b/tests/TestLowerIsListPatternExpression.cs
@@ -1,0 +1,732 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SharpSyntaxRewriter.Rewriters;
+
+namespace Tests
+{
+    [TestClass]
+    public class TestLowerIsListPatternExpression : RewriterTester
+    {
+        protected override SyntaxTree ApplyRewrite(SyntaxTree tree, Compilation compilation)
+        {
+            return new LowerIsListPatternExpression().Apply(tree, compilation.GetSemanticModel(tree));
+        }
+
+        [TestMethod]
+        public void TestArraysSingleElementIsThisNumericConstant()
+        {
+            var original = @"
+class C
+{
+    bool M(int[] x)
+    {
+        return x is [1];
+    }
+}";
+            var expected = @"
+class C
+{
+    bool M(int[] x)
+    {
+        return x != null && x.Length == 1 && ((int)x[0] == 1);
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArraySingleElementIsNotNumericConstant()
+        {
+            var original = @"
+class C
+{
+    bool M(int[] x)
+    {
+        return x is [not 0];
+    }
+}";
+            var expected = @"
+class C
+{
+    bool M(int[] x)
+    {
+        return x != null && x.Length == 1 && (!((int)x[0] == 0));
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+
+        [TestMethod]
+        public void TestArraysSingleElementIsThisNumericConstantOrThatNumericConstant()
+        {
+            var original = @"
+class C
+{
+    bool M(int[] x)
+    {
+        return x is [10 or 20];
+    }
+}";
+            var expected = @"
+class C
+{
+    bool M(int[] x)
+    {
+        return x != null && x.Length == 1 && ((int)x[0] == 10 || (int)x[0] == 20);
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArraysSingleElementIsEitherIntOrDouble()
+        {
+            var original = @"
+class C
+{
+    bool M(object[] x)
+    {
+        return x is [int or double];
+    }
+}";
+            var expected = @"
+class C
+{
+    bool M(object[] x)
+    {
+        return x != null && x.Length == 1 && (x[0] is int || x[0] is double);
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArraysSingleElementIsIntAndZero()
+        {
+            var original = @"
+class C
+{
+    bool M(object[] x)
+    {
+        return x is [int and 0];
+    }
+}";
+            var expected = @"
+class C
+{
+    bool M(object[] x)
+    {
+        return x != null && x.Length == 1 && (x[0] is int && (int)x[0] == 0);
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArraysSingleElementIsNotIntOrIsDouble()
+        {
+            var original = @"
+class C
+{
+    bool M(object[] x)
+    {
+        return x is [not int or double];
+    }
+}";
+            var expected = @"
+class C
+{
+    bool M(object[] x)
+    {
+        return x != null && x.Length == 1 && (!(x[0] is int) || x[0] is double);
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArraysSingleElementIsNotIntOrDouble()
+        {
+            var original = @"
+class C
+{
+    bool M(object[] x)
+    {
+        return x is [not (int or double)];
+    }
+}";
+            var expected = @"
+class C
+{
+    bool M(object[] x)
+    {
+        return x != null && x.Length == 1 && (!((x[0] is int || x[0] is double)));
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [DataTestMethod]
+        [DataRow(">")]
+        [DataRow("<")]
+        [DataRow(">=")]
+        [DataRow("<=")]
+        public void TestArraysSingleElementIsInRelationWithNumericConstant(string relOp)
+        {
+            var original = $@"
+class C
+{{
+    bool M(int[] x)
+    {{
+        return x is [{relOp} 0];
+    }}
+}}";
+            var expected = $@"
+class C
+{{
+    bool M(int[] x)
+    {{
+        return x != null && x.Length == 1 && (x[0] {relOp} 0);
+    }}
+}}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArraysSingleElementIsGreaterThanAndLesserThanIntegerLiterals()
+        {
+            var original = @"
+class C
+{
+    bool M(int[] x)
+    {
+        return x is [>0 and <100];
+    }
+}";
+            var expected = @"
+class C
+{
+    bool M(int[] x)
+    {
+        return x != null && x.Length == 1 && (x[0] > 0 && x[0] < 100);
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+        
+        
+        [TestMethod]
+        public void TestArrayIsEmptyPattern()
+        {
+            var original = @"
+class C
+{
+    void M(int[] arr)
+    {
+        System.Console.WriteLine(arr is []);
+    }
+}";
+            var expected = @"
+class C
+{
+    void M(int[] arr)
+    {
+        System.Console.WriteLine(arr != null && arr.Length == 0);
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArraysSingleElementIsSlicePattern()
+        {
+            var original = @"
+class C
+{
+    void M(int[] arr)
+    {
+        System.Console.WriteLine(arr is [..]);
+    }
+}";
+            var expected = @"
+class C
+{
+    void M(int[] arr)
+    {
+        System.Console.WriteLine(arr != null && arr.Length >= 0);
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArraysSingleElementIsSliceDiscardPattern()
+        {
+            var original = @"
+class C
+{
+    void M(int[] arr)
+    {
+        System.Console.WriteLine(arr is [.. _]);
+    }
+}";
+            var expected = @"
+class C
+{
+    void M(int[] arr)
+    {
+        System.Console.WriteLine(arr != null && arr.Length >= 0);
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArraysSingleElementIsSliceVarDiscardPattern()
+        {
+            var original = @"
+class C
+{
+    bool M(int[] arr)
+    {
+        return arr is [.. var _];
+    }
+}";
+            var expected = @"
+class C
+{
+    bool M(int[] arr)
+    {
+        return arr != null && arr.Length >= 0;
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+        
+        [TestMethod]
+        public void TestArraysSingleElementIsSliceVarPattern()
+        {
+            var original = @"
+class C
+{
+    void M(int[] arr)
+    {
+        System.Console.WriteLine(arr is [.. var arr2]);
+    }
+}";
+            var expected = @"
+class C
+{
+    void M(int[] arr)
+    {
+        System.Console.WriteLine(arr != null && arr.Length >= 0 && (arr[0..^0] is var arr2));
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArrayIsExactlyTheseTwoElements()
+        {
+            var original = @"
+class C
+{
+    void M(int[] arr)
+    {
+        System.Console.WriteLine(arr is [3,4]);
+    }
+}";
+
+            var expected = @"
+class C
+{
+    void M(int[] arr)
+    {
+        System.Console.WriteLine(arr != null && arr.Length == 2 && ((int)arr[0] == 3) && ((int)arr[1] == 4));
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArraysSingleElementIsEitherThisOrThat()
+        {
+            var original = @"
+class C
+{
+    void M(int[] arr)
+    {
+        System.Console.WriteLine(arr is [3 or 4]);
+    }
+}";
+            var expected = @"
+class C
+{
+    void M(int[] arr)
+    {
+        System.Console.WriteLine(arr != null && arr.Length == 1 && ((int)arr[0] == 3 || (int)arr[0] == 4));
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArrayContainsExactlyThreeElementsUsingDiscardPatterns()
+        {
+            var original = @"
+class C
+{
+    bool M(int[] arr)
+    {
+        return arr is [_,_,_];
+    }
+}";
+            var expected = @"
+class C
+{
+    bool M(int[] arr)
+    {
+        return arr != null && arr.Length == 3;
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArrayContainsAtLeastTwoElementsUsingSliceAndDiscardPatterns()
+        {
+            var original = @"
+class C
+{
+    bool M(int[] arr)
+    {
+        return arr is [_, .., _];
+    }
+}";
+            var expected = @"
+class C
+{
+    bool M(int[] arr)
+    {
+        return arr != null && arr.Length >= 2;
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArrayContainsSingleElementUsingVarAndDiscardPattern()
+        {
+            var original = @"
+class C
+{
+    bool M(int[] arr)
+    {
+        return arr is [var _];
+    }
+}";
+            var expected = @"
+class C
+{
+    bool M(int[] arr)
+    {
+        return arr != null && arr.Length == 1;
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestSplitArrayIntoHeadAndTail()
+        {
+            var original = @"
+class C
+{
+    bool M(int[] arr)
+    {
+        return arr is [var head, .. var tail];
+    }
+}";
+            var expected = @"
+class C
+{
+    bool M(int[] arr)
+    {
+        return arr != null && arr.Length >= 1 && (arr[0] is var head) && (arr[1..^0] is var tail);
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArrayEndsWithTheseTwoConstants()
+        {
+            var original = @"
+class C
+{
+    bool M(int[] arr)
+    {
+        return arr is [.., 3, 4];
+    }
+}";
+            var expected = @"
+class C
+{
+    bool M(int[] arr)
+    {
+        return arr != null && arr.Length >= 2 && ((int)arr[^2] == 3) && ((int)arr[^1] == 4);
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestNestedArraysSingleElementIsSingleArray()
+        {
+            var original = @"
+class C
+{
+    bool M(int[][] arr)
+    {
+        return arr is [[1]];
+    }
+}";
+            var expected = @"
+class C
+{
+    bool M(int[][] arr)
+    {
+        return arr != null && arr.Length == 1 && (arr[0] != null && arr[0].Length == 1 && ((int)arr[0][0] == 1));
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArraysSingleElementIsPropertyPattern()
+        {
+            var original = @"
+using System;
+class C
+{
+    bool M(DateTime[] arr)
+    {
+        return arr is [{Month:10}];
+    }
+}";
+            var expected = @"
+using System;
+class C
+{
+    bool M(DateTime[] arr)
+    {
+        return arr != null && arr.Length == 1 && (arr[0] is {Month:10});
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestIsListPatternLoweringDoesNotOccurInSwitchCases()
+        {
+            var original = @"
+class C
+{
+    bool M(int[] arr)
+    {
+        switch (arr)
+        {
+            case []: return false;
+            default: return true;
+        }
+    }
+}";
+            TestRewrite_LinePreserve(original, original);
+        }
+
+        [TestMethod]
+        public void TestIsListPatternLoweringDoesNotOccurOutsideOfListPatterns()
+        {
+            var original = @"
+class C
+{
+    bool M(int x)
+    {
+        return x is 0;
+    }
+}";
+            TestRewrite_LinePreserve(original, original);
+        }
+
+        [TestMethod]
+        public void TestArraysSingleElementIsVarPatternInLogicalAnd()
+        {
+            var original = @"
+class C
+{
+    bool M(int[] arr)
+    {
+        return arr is [var head] && head == 1;
+    }
+}";
+            var expected = @"
+class C
+{
+    bool M(int[] arr)
+    {
+        return arr != null && arr.Length == 1 && (arr[0] is var head) && head == 1;
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArraysSingleElementIsConstantEnumMember()
+        {
+            var original = @"
+enum E
+{
+    F
+};
+class C
+{
+    bool M(object[] arr)
+    {
+        return arr is [E.F];
+    }
+}";
+            var expected = @"
+enum E
+{
+    F
+};
+class C
+{
+    bool M(object[] arr)
+    {
+        return arr != null && arr.Length == 1 && ((E)arr[0] == E.F);
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestListsSingleElementIsConstant()
+        {
+            var original = @"
+using System.Collections.Generic;
+class C
+{
+    bool M(List<int> list)
+    {
+        return list is [0];
+    }
+}";
+            var expected = @"
+using System.Collections.Generic;
+class C
+{
+    bool M(List<int> list)
+    {
+        return list != null && list.Count == 1 && ((int)list[0] == 0);
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestListsSingleElementIsArrayWhoseSingleElementIsConstant()
+        {
+            var original = @"
+using System.Collections.Generic;
+class C
+{
+    bool M(List<int[]> list)
+    {
+        return list is [[10]];
+    }
+}";
+            var expected = @"
+using System.Collections.Generic;
+class C
+{
+    bool M(List<int[]> list)
+    {
+        return list != null && list.Count == 1 && (list[0] != null && list[0].Length == 1 && ((int)list[0][0] == 10));
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+        
+        [TestMethod]
+        public void TestArraysSingleElementIsListWhoseSingleElementIsConstant()
+        {
+            var original = @"
+using System.Collections.Generic;
+class C
+{
+    bool M(List<int>[] arr)
+    {
+        return arr is [[10]];
+    }
+}";
+            var expected = @"
+using System.Collections.Generic;
+class C
+{
+    bool M(List<int>[] arr)
+    {
+        return arr != null && arr.Length == 1 && (arr[0] != null && arr[0].Count == 1 && ((int)arr[0][0] == 10));
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+        
+        [TestMethod]
+        public void TestSpansSingleElementIsConstant()
+        {
+            var original = @"
+using System;
+class C
+{
+    bool M(Span<int> span)
+    {
+        return span is [10];
+    }
+}";
+            var expected = @"
+using System;
+class C
+{
+    bool M(Span<int> span)
+    {
+        return span != null && span.Length == 1 && ((int)span[0] == 10);
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+
+        [TestMethod]
+        public void TestArraysSinglePatternIsSlicePropertyPattern()
+        {
+            var original = @"
+class C
+{
+    bool M(int[] arr)
+    {
+        return arr is [.. { Length: 2 or 4 }];
+    }
+}";
+            var expected = @"
+class C
+{
+    bool M(int[] arr)
+    {
+        return arr != null && arr.Length >= 0 && (arr[0..^0] is {Length: 2 or 4});
+    }
+}";
+            TestRewrite_LinePreserve(original, expected);
+        }
+    }
+}

--- a/tests/Tests.csproj
+++ b/tests/Tests.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.3.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.1.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This patch rewrites an `is <list-pattern>` expression into a series of simpler conjunctions. E.g. 

```c#
x is [< 0, var second, .. var rest]
```

becomes

```c#
x != null && x.Length >= 2 && (x[0] < 0) && (x[1] is var second) && (x[2 .. ^0] is var rest)
```

Check the unit-tests for more examples.

References:
* https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/operators/patterns#list-patterns
* https://learn.microsoft.com/en-gb/dotnet/csharp/language-reference/operators/patterns