### PR TITLE
Bumping version: 1.0.60

### DIFF
--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>SharpSyntaxRewriter</PackageId>
-    <PackageVersion>1.0.59</PackageVersion>
+    <PackageVersion>1.0.60</PackageVersion>
     <Authors>Leandro T. C. Melo</Authors>
     <Copyright>ShiftLeft Inc.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>


### PR DESCRIPTION
...so that the last rewrite (PR https://github.com/ShiftLeftSecurity/SharpSyntaxRewriter/pull/46) can eventually be made available with a simple upgrade.