### PR TITLE
Support for arrow expression constructors in DecomposeNullConditional

### DIFF
--- a/src/SharpSyntaxRewriter/Rewriters/DecomposeNullConditional.cs
+++ b/src/SharpSyntaxRewriter/Rewriters/DecomposeNullConditional.cs
@@ -4,7 +4,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -171,6 +170,11 @@ namespace SharpSyntaxRewriter.Rewriters
 
         public override SyntaxNode VisitConstructorDeclaration(ConstructorDeclarationSyntax node)
         {
+            if (node.ExpressionBody is not null)
+            {
+                return node.WithExpressionBody((ArrowExpressionClauseSyntax)node.ExpressionBody.Accept(this));
+            }
+
             return node.WithBody((BlockSyntax)node.Body.Accept(this));
         }
 

--- a/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
+++ b/src/SharpSyntaxRewriter/SharpSyntaxRewriter.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>SharpSyntaxRewriter</PackageId>
-    <PackageVersion>1.0.60</PackageVersion>
+    <PackageVersion>1.0.61</PackageVersion>
     <Authors>Leandro T. C. Melo</Authors>
     <Copyright>ShiftLeft Inc.</Copyright>
     <NeutralLanguage>en-US</NeutralLanguage>

--- a/tests/TestDecomposeNullConditional.cs
+++ b/tests/TestDecomposeNullConditional.cs
@@ -883,5 +883,26 @@ class Test
 
             TestRewrite_LinePreserve(original, expected);
         }
+
+        [TestMethod]
+        public void TestDecomposeNullConditionalWithArrowExpressionConstructor()
+        {
+            var original = @"
+class C
+{
+    string r;
+    C(int? x) => r = x?.ToString() ?? ""was null"";
+}
+";
+
+            var expected = @"
+class C
+{
+    string r;
+    C(int? x) => r = ((object)x.Value == null) ? null : x.Value.ToString() ?? ""was null"";
+}
+";
+            TestRewrite_LinePreserve(original, expected);
+        }
     }
 }


### PR DESCRIPTION
...and thus preventing a simple null pointer exception.